### PR TITLE
Fix：フィルタリング機能の修正

### DIFF
--- a/lib/shared/providers/practice_menu_provider.dart
+++ b/lib/shared/providers/practice_menu_provider.dart
@@ -145,13 +145,16 @@ final errorMessageProvider = Provider<String?>((ref) {
 });
 
 final categoriesProvider = Provider<List<String>>((ref) {
-  return ref.watch(practiceMenuProvider.notifier).getCategories();
+  ref.watch(practiceMenuProvider);
+  return ref.read(practiceMenuProvider.notifier).getCategories();
 });
 
 final typesProvider = Provider<List<String>>((ref) {
-  return ref.watch(practiceMenuProvider.notifier).getTypes();
+  ref.watch(practiceMenuProvider);
+  return ref.read(practiceMenuProvider.notifier).getTypes();
 });
 
 final difficultiesProvider = Provider<List<String>>((ref) {
-  return ref.watch(practiceMenuProvider.notifier).getDifficulties();
+  ref.watch(practiceMenuProvider);
+  return ref.read(practiceMenuProvider.notifier).getDifficulties();
 });


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

### 概要 & 関連資料
<!-- issue番号を # の後に入れると PR merge 時に close される -->
- close #70 

### 変更内容
<!-- どのような変更をしたか -->
<!-- ex.) ユーザーがアプリを楽しく使えるようにタスク完了時にアニメーションをつけた -->

**原因**
`ref.watch(practiceMenuProvider.notifier)` を使っていたため，`practiceMenuProvider` の `state（中身）` が変わっても再評価されず，カテゴリ／タイプ／難易度の一覧が更新されていなかった．

**解決**
`ref.watch(practiceMenuProvider)`で`state` を監視するようにし，状態変化でプロバイダーが再評価されるようにしたため，一覧が正しく更新されるようにできた．

### 影響範囲
<!-- どの画面に影響するか -->
<!-- ex.) タスク一覧画面 -->

- 

### 備考
<!-- レビューに関してのコメントなど -->
<!-- ex.) ダークモードへの対応はできてないが、後で対応するのでスルーして下さい -->
<!-- ex.) 動作確認のためには、.envにENV=trueを追記して下さい -->

- 

### セルフチェック
- [ ] 環境変数などがPRに含まれていないか

<!-- I want to review in Japanese. -->
