### PR TITLE
Fix: LED設定の初期化ロジックを改善し、フェーズ数に応じたクリア色の初期化を追加

### DIFF
--- a/lib/pages/note_page/color_setting_page.dart
+++ b/lib/pages/note_page/color_setting_page.dart
@@ -47,7 +47,7 @@ class _ColorSettingPageState extends State<ColorSettingPage> {
             return ledColors[phaseIndex];
           } else {
             // フェーズ数：編集設定＞既存設定の場合
-            // 新しく追加されたフェーズ，全てのLEDをクリア色で初期化
+            // 新しく追加されたフェーズ，すべてのLEDをクリア色で初期化
             return LedColor.clear;
           }
         });


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

### 概要 & 関連資料
<!-- issue番号を # の後に入れると PR merge 時に close される -->
- close #83 

### 変更内容
<!-- どのような変更をしたか -->
<!-- ex.) ユーザーがアプリを楽しく使えるようにタスク完了時にアニメーションをつけた -->

- 練習メニューの編集時にフェーズ数やLED数を増やした際にColorSettingPageがクラッシュする問題を修正
- 既存の色設定配列のサイズと新しいフェーズ数・LED数が一致しない場合に，不足分をデフォルト色（消灯）で補完するように変更

### 影響範囲
<!-- どの画面に影響するか -->
<!-- ex.) タスク一覧画面 -->

- 色設定ページ（ColorSettingPage）
- 練習メニュー編集フロー

### 備考
<!-- レビューに関してのコメントなど -->
<!-- ex.) ダークモードへの対応はできてないが、後で対応するのでスルーして下さい -->
<!-- ex.) 動作確認のためには、.envにENV=trueを追記して下さい -->

- フェーズ数やLED数を減らす場合は，既存の色設定が自動的にトリミングされます
- 新しく追加されたフェーズ・LEDにはLedColor.clear（クリア）がデフォルトで設定されます

### セルフチェック
- [ ] 環境変数などがPRに含まれていないか

<!-- I want to review in Japanese. -->
