### PR TITLE
FEAT:bluetooth接続をプログレスバーに変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,39 @@ flutter run
 flutter test
 ```
 
+## デバッグモード（`DEBUG`フラグ）
+
+BLE関連のUI動作確認をシミュレータや実機で行うためのモックモードです。
+
+### 有効化方法
+
+`.env` ファイルで設定されています：
+```
+DEBUG=true
+```
+VS Codeからの起動時は `launch.json` の `--dart-define-from-file=.env` により自動で読み込まれます。
+コマンドラインから直接指定する場合：
+```bash
+flutter run --dart-define=DEBUG=true
+```
+
+### 影響範囲
+
+| ファイル | `DEBUG=true` の挙動 |
+|---|---|
+| `discovered_device_list.dart` | スキャン前にダミーBLEデバイス3台を初期表示する。スキャン開始後にストリームからデータが来ると、ダミーは実デバイスに置き換わる |
+| `provisioning_progress_dialog.dart` | **ダミーデバイスを選択した場合のみ**モックプロビジョニング（2秒間隔で各ステップを擬似進行）を実行する。実デバイスを選択した場合は通常のBLEプロビジョニングが動作する |
+| `network_node_list.dart` | ノードリスト取得時に1秒のローディング遅延を追加する |
+
+### プロビジョニングのモック判定
+
+モックプロビジョニングの実行はグローバルな`DEBUG`フラグではなく、**選択されたデバイスがダミーかどうか**で判定されます：
+
+- **ダミーデバイス**（UUIDが `_testDevices` に一致） → モックプロビジョニング
+- **実デバイス** → 通常のBLEプロビジョニング
+
+そのため、`DEBUG=true` の状態で実機を接続しても、スキャンで検出された実デバイスは通常通りプロビジョニングできます。
+
 ## 貢献について
 効果的なチーム開発のために，[CONTRIBUTING.md](https://github.com/human-interface-lab-soccer/soccer-app-flutter/blob/main/CONTRIBUTING.md) に記載されている開発ルール，ブランチ戦略などのガイドラインを必ず確認してください．
 <!-- 川崎です -->

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -45,12 +45,12 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Firebase: 3435bc66b4d494c2f22c79fd3aae4c1db6662327
-  firebase_core: 700bac7ed92bb754fd70fbf01d72b36ecdd6d450
+  firebase_core: a861be150c0e7c6aecedde077968eb92cbf790b9
   FirebaseCore: c692c7f1c75305ab6aff2b367f25e11d73aa8bd0
   FirebaseCoreInternal: 29d7b3af4aaf0b8f3ed20b568c13df399b06f68c
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
 
 PODFILE CHECKSUM: 251cb053df7158f337c0712f2ab29f4e0fa474ce
 

--- a/ios/Runner/Bluetooth/ProvisioningService.swift
+++ b/ios/Runner/Bluetooth/ProvisioningService.swift
@@ -31,8 +31,7 @@ class ProvisioningService: NSObject {
     private var unprovisionedDevice: UnprovisionedDevice?
     private var provisioningManager: ProvisioningManager?
 
-    init(meshNetworkManager: MeshNetworkManager, bleScanner: GeneralBleScanner)
-    {
+    init(meshNetworkManager: MeshNetworkManager, bleScanner: GeneralBleScanner) {
         self.meshNetworkManager = meshNetworkManager
         self.bleScanner = bleScanner
         self._provisioningEventStreamHandler = ProvisioningEventStreamHandler()
@@ -57,7 +56,7 @@ class ProvisioningService: NSObject {
                 as? [String: Any]
         else {
             result([
-                "isSuccess": false, "body": "Device not found in scan results.",
+                "isSuccess": false, "message": "Device not found in scan results.",
             ])
             return
         }
@@ -69,7 +68,7 @@ class ProvisioningService: NSObject {
         else {
             result([
                 "isSuccess": false,
-                "body": "The device is not a valid unprovisioned device.",
+                "message": "The device is not a valid unprovisioned device.",
             ])
             return
         }
@@ -91,13 +90,13 @@ class ProvisioningService: NSObject {
                 ]
             )
             result([
-                "isSuccess": true, "body": "Provisioning process initiated.",
+                "isSuccess": true, "message": "Provisioning process initiated.",
             ])
         } catch {
             cleanupProvisioning()
             result([
                 "isSuccess": false,
-                "body": "Failed to open bearer: \(error.localizedDescription)",
+                "message": "Failed to open bearer: \(error.localizedDescription)",
             ])
         }
     }

--- a/ios/Runner/Bluetooth/ProvisioningService.swift
+++ b/ios/Runner/Bluetooth/ProvisioningService.swift
@@ -178,14 +178,14 @@ class ProvisioningService: NSObject {
 extension ProvisioningService: GattBearerDelegate {
     func bearerDidConnect(_ bearer: Bearer) {
         _provisioningEventStreamHandler.sendEvent(
-            status: .connecting,
+            status: .discovering,
             data: ["message": "Discovering services..."]
         )
     }
 
     func bearerDidDiscoverServices(_ bearer: Bearer) {
         _provisioningEventStreamHandler.sendEvent(
-            status: .connecting,
+            status: .discovering,
             data: ["message": "Initializing..."]
         )
     }

--- a/lib/pages/connection_page/discovered_device_list.dart
+++ b/lib/pages/connection_page/discovered_device_list.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:soccer_app_flutter/features/platform_channels/general_ble_scanner.dart';
 import 'package:soccer_app_flutter/shared/models/ble_device.dart';
-import 'package:soccer_app_flutter/features/platform_channels/provisioning.dart';
+import 'package:soccer_app_flutter/pages/connection_page/provisioning_progress_dialog.dart';
 
 /// 検出されたBLEデバイスのリストを表示するウィジェット
 ///
@@ -57,7 +57,6 @@ class _DiscoveredDeviceListState extends State<DiscoveredDeviceList> {
   ];
 
   final GeneralBleScanner generalBleScanner = GeneralBleScanner();
-  final Provisioning _provisioning = Provisioning();
   bool isScanning = false;
 
   Future<void> handleScanButtonPressed() async {
@@ -84,42 +83,17 @@ class _DiscoveredDeviceListState extends State<DiscoveredDeviceList> {
     }
   }
 
-  Future<void> handleStartProvisioning(String uuid) async {
-    Map<String, dynamic> response = await _provisioning.startProvisioning(uuid);
-    if (!mounted) return;
-
-    bool isSuccess = response['isSuccess'] ?? false;
-    String message = response['message'] ?? 'No message provided';
-
-    if (isSuccess) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text("Provisioning successfully started")),
-      );
-      // streamを購読して、プロビジョニングの進捗を受け取る
-      _provisioning.provisioningStream.listen(
-        (data) {
-          if (!mounted) return;
-          SnackBar snackBar = SnackBar(
-            content: Text(
-              '${data['status'] ?? 'Unknown'}: ${data["message"] ?? ""}',
-            ),
-          );
-          ScaffoldMessenger.of(context).showSnackBar(snackBar);
-        },
-        onError: (error) {
-          if (!mounted) return;
-          ScaffoldMessenger.of(
-            context,
-          ).showSnackBar(SnackBar(content: Text('Provisioning error: $error')));
-        },
-      );
-    } else {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text("error: $message")));
-    }
-    // close the dialog after provisioning
-    Navigator.of(context).pop();
+  Future<void> handleStartProvisioning(BleDevice device) async {
+    // ダイアログを表示（barrierDismissibleをfalseにして，ユーザーが誤って閉じないようにする）
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder:
+          (context) => ProvisioningProgressDialog(
+            deviceName: device.name,
+            deviceUuid: device.uuid,
+          ),
+    );
   }
 
   @override
@@ -154,37 +128,7 @@ class _DiscoveredDeviceListState extends State<DiscoveredDeviceList> {
                             subtitle: Text(
                               'UUID: ${device.uuid}, RSSI: ${device.rssi}',
                             ),
-                            onTap: () async {
-                              showDialog(
-                                context: context,
-                                builder: (context) {
-                                  return SimpleDialog(
-                                    title: Text('Provisioning ${device.name}'),
-                                    children: [
-                                      Padding(
-                                        padding: const EdgeInsets.all(16.0),
-                                        child: Text(
-                                          'UUID: ${device.uuid}',
-                                          style: const TextStyle(fontSize: 16),
-                                        ),
-                                      ),
-                                      Padding(
-                                        padding: const EdgeInsets.all(16.0),
-                                        child: ElevatedButton(
-                                          onPressed:
-                                              () => handleStartProvisioning(
-                                                device.uuid,
-                                              ),
-                                          child: const Text(
-                                            'Start Provisioning',
-                                          ),
-                                        ),
-                                      ),
-                                    ],
-                                  );
-                                },
-                              );
-                            },
+                            onTap: () => handleStartProvisioning(device),
                           );
                         },
                       ).toList(),

--- a/lib/pages/connection_page/discovered_device_list.dart
+++ b/lib/pages/connection_page/discovered_device_list.dart
@@ -84,7 +84,29 @@ class _DiscoveredDeviceListState extends State<DiscoveredDeviceList> {
   }
 
   Future<void> handleStartProvisioning(BleDevice device) async {
-    // ダイアログを表示（barrierDismissibleをfalseにして，ユーザーが誤って閉じないようにする）
+    // 確認ダイアログを表示
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder:
+          (context) => AlertDialog(
+            title: const Text('プロビジョニング開始'),
+            content: Text('${device.name} のプロビジョニングを開始しますか？'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('キャンセル'),
+              ),
+              ElevatedButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                child: const Text('開始'),
+              ),
+            ],
+          ),
+    );
+
+    if (confirmed != true || !mounted) return;
+
+    // プロビジョニング進捗ダイアログを表示
     showDialog(
       context: context,
       barrierDismissible: false,

--- a/lib/pages/connection_page/discovered_device_list.dart
+++ b/lib/pages/connection_page/discovered_device_list.dart
@@ -106,6 +106,9 @@ class _DiscoveredDeviceListState extends State<DiscoveredDeviceList> {
 
     if (confirmed != true || !mounted) return;
 
+    // テストデバイスかどうかを判定
+    final isMock = _testDevices.any((d) => d.uuid == device.uuid);
+
     // プロビジョニング進捗ダイアログを表示
     showDialog(
       context: context,
@@ -114,6 +117,7 @@ class _DiscoveredDeviceListState extends State<DiscoveredDeviceList> {
           (context) => ProvisioningProgressDialog(
             deviceName: device.name,
             deviceUuid: device.uuid,
+            isMockDevice: isMock,
           ),
     );
   }

--- a/lib/pages/connection_page/provisioning_progress_dialog.dart
+++ b/lib/pages/connection_page/provisioning_progress_dialog.dart
@@ -66,7 +66,7 @@ enum ProvisioningStep {
     }
   }
 
-  ///ステップのアイコンを取得
+  /// ステップのアイコンを取得
   IconData get icon {
     switch (this) {
       case ProvisioningStep.connecting:

--- a/lib/pages/connection_page/provisioning_progress_dialog.dart
+++ b/lib/pages/connection_page/provisioning_progress_dialog.dart
@@ -1,0 +1,402 @@
+import 'package:flutter/material.dart';
+import 'package:soccer_app_flutter/features/platform_channels/provisioning.dart';
+
+/// プロビジョニングの進捗状態を表す列挙型
+enum ProvisioningStep {
+  connecting,
+  discovering,
+  identifying,
+  provisioning,
+  complete,
+  error;
+
+  /// ステータス文字列から列挙型に変換
+  static ProvisioningStep fromStatus(String status) {
+    switch (status.toLowerCase()) {
+      case 'connecting':
+        return ProvisioningStep.connecting;
+      case 'discovering':
+        return ProvisioningStep.discovering;
+      case 'identifying':
+        return ProvisioningStep.identifying;
+      case 'provisioning':
+        return ProvisioningStep.provisioning;
+      case 'complete':
+        return ProvisioningStep.complete;
+      case 'error':
+        return ProvisioningStep.error;
+      default:
+        return ProvisioningStep.connecting;
+    }
+  }
+
+  /// ステップのインデクスを取得（プログレスバー用）
+  int get stepIndex {
+    switch (this) {
+      case ProvisioningStep.connecting:
+        return 0;
+      case ProvisioningStep.discovering:
+        return 1;
+      case ProvisioningStep.identifying:
+        return 2;
+      case ProvisioningStep.provisioning:
+        return 3;
+      case ProvisioningStep.complete:
+        return 4;
+      case ProvisioningStep.error:
+        return -1;
+    }
+  }
+
+  /// ステップの日本語名を取得
+  String get displayName {
+    switch (this) {
+      case ProvisioningStep.connecting:
+        return '接続中';
+      case ProvisioningStep.discovering:
+        return 'サービス検索中';
+      case ProvisioningStep.identifying:
+        return '識別中';
+      case ProvisioningStep.provisioning:
+        return 'プロビジョニング中';
+      case ProvisioningStep.complete:
+        return '完了';
+      case ProvisioningStep.error:
+        return 'エラー';
+    }
+  }
+
+  ///ステップのアイコンを取得
+  IconData get icon {
+    switch (this) {
+      case ProvisioningStep.connecting:
+        return Icons.bluetooth;
+      case ProvisioningStep.discovering:
+        return Icons.bluetooth_searching;
+      case ProvisioningStep.identifying:
+        return Icons.search;
+      case ProvisioningStep.provisioning:
+        return Icons.settings;
+      case ProvisioningStep.complete:
+        return Icons.check_circle;
+      case ProvisioningStep.error:
+        return Icons.error;
+    }
+  }
+
+  /// ステップの色を取得
+  Color get color {
+    switch (this) {
+      case ProvisioningStep.complete:
+        return Colors.green;
+      case ProvisioningStep.error:
+        return Colors.red;
+      default:
+        return Colors.blue;
+    }
+  }
+}
+
+/// プロビジョニング進捗ダイアログ
+///
+/// BLEデバイスのプロビジョニング進捗をステップ表示付きプログレスバーで表示します．
+///
+/// ### 使用例:
+/// ```dart
+/// showDialog(
+///   context: context,
+///   barrierDismissible: false,
+///   builder: (context) => ProvisioningProgressDialog(
+///     deviceName: 'My Device',
+///     deviceUuid: 'xxxx-xxxx-xxxx',
+///   ),
+/// );
+/// ```
+class ProvisioningProgressDialog extends StatefulWidget {
+  final String deviceName;
+  final String deviceUuid;
+
+  const ProvisioningProgressDialog({
+    super.key,
+    required this.deviceName,
+    required this.deviceUuid,
+  });
+
+  @override
+  State<ProvisioningProgressDialog> createState() =>
+      _ProvisioningProgressDialogState();
+}
+
+class _ProvisioningProgressDialogState
+    extends State<ProvisioningProgressDialog> {
+  final Provisioning _provisioning = Provisioning();
+  ProvisioningStep _currentStep = ProvisioningStep.connecting;
+  String _statusMessage = 'プロビジョニングを開始しています...';
+  bool _isCompleted = false;
+  bool _hasError = false;
+
+  // 全ステップ（エラーを除く）
+  static const List<ProvisioningStep> _allSteps = [
+    ProvisioningStep.connecting,
+    ProvisioningStep.discovering,
+    ProvisioningStep.identifying,
+    ProvisioningStep.provisioning,
+    ProvisioningStep.complete,
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _startProvisioning();
+  }
+
+  Future<void> _startProvisioning() async {
+    try {
+      // プロビジョニング開始
+      final response = await _provisioning.startProvisioning(widget.deviceUuid);
+
+      if (!response['isSuccess']) {
+        if (!mounted) return;
+        setState(() {
+          _currentStep = ProvisioningStep.error;
+          _statusMessage = 'エラー: ${response['message']}';
+          _hasError = true;
+        });
+        return;
+      }
+
+      // プロビジョニングストリームを購読
+      _provisioning.provisioningStream.listen(
+        (data) {
+          if (!mounted) return;
+
+          final status = data['status'] as String? ?? 'unknown';
+          final message = data['message'] as String? ?? '';
+
+          setState(() {
+            _currentStep = ProvisioningStep.fromStatus(status);
+            _statusMessage = message;
+
+            if (_currentStep == ProvisioningStep.complete) {
+              _isCompleted = true;
+            } else if (_currentStep == ProvisioningStep.error) {
+              _hasError = true;
+            }
+          });
+        },
+        onError: (error) {
+          if (!mounted) return;
+          setState(() {
+            _currentStep = ProvisioningStep.error;
+            _statusMessage = 'エラーが発生しました: $error';
+            _hasError = true;
+          });
+        },
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _currentStep = ProvisioningStep.error;
+        _statusMessage = '予期しないエラー: $e';
+        _hasError = true;
+      });
+    }
+  }
+
+  /// 現在の進捗率を計算（0.0 ~ 1.0）
+  double get _progressValue {
+    if (_hasError) return 0.0;
+    if (_isCompleted) return 1.0;
+
+    final currentIndex = _currentStep.stepIndex;
+    if (currentIndex < 0) return 0.0;
+
+    return (currentIndex + 1) / _allSteps.length;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.0)),
+      child: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // タイトル
+            Text(
+              widget.deviceName,
+              style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'UUID: ${widget.deviceUuid}',
+              style: const TextStyle(fontSize: 12, color: Colors.grey),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+
+            // プログレスバー
+            LinearProgressIndicator(
+              value: _progressValue,
+              backgroundColor: Colors.grey[300],
+              valueColor: AlwaysStoppedAnimation<Color>(
+                _hasError ? Colors.red : Colors.blue,
+              ),
+              minHeight: 8,
+            ),
+            const SizedBox(height: 16),
+
+            // 現在のステップインジケーター
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children:
+                  _allSteps.map((step) {
+                    final isActive = step.stepIndex <= _currentStep.stepIndex;
+                    final isCurrent = step == _currentStep;
+
+                    return Expanded(
+                      child: Column(
+                        children: [
+                          Container(
+                            width: 48,
+                            height: 48,
+                            decoration: BoxDecoration(
+                              shape: BoxShape.circle,
+                              color:
+                                  isActive || isCurrent
+                                      ? step.color.withValues(alpha: 0.2)
+                                      : Colors.grey[300],
+                              border: Border.all(
+                                color:
+                                    isActive || isCurrent
+                                        ? step.color
+                                        : Colors.grey,
+                                width: isCurrent ? 3 : 2,
+                              ),
+                            ),
+                            child: Icon(
+                              step.icon,
+                              color:
+                                  isActive || isCurrent
+                                      ? step.color
+                                      : Colors.grey,
+                              size: 24,
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            step.displayName,
+                            style: TextStyle(
+                              fontSize: 10,
+                              fontWeight:
+                                  isCurrent
+                                      ? FontWeight.bold
+                                      : FontWeight.normal,
+                              color:
+                                  isActive || isCurrent
+                                      ? Colors.black
+                                      : Colors.grey,
+                            ),
+                            textAlign: TextAlign.center,
+                          ),
+                        ],
+                      ),
+                    );
+                  }).toList(),
+            ),
+            const SizedBox(height: 24),
+
+            // エラー表示
+            if (_hasError)
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Colors.red[50],
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: Colors.red),
+                ),
+                child: Row(
+                  children: [
+                    const Icon(Icons.error, color: Colors.red),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Text(
+                        _statusMessage,
+                        style: const TextStyle(color: Colors.red),
+                      ),
+                    ),
+                  ],
+                ),
+              )
+            else if (_isCompleted)
+              // 完了表示
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Colors.green[50],
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: Colors.green),
+                ),
+                child: Row(
+                  children: [
+                    const Icon(Icons.check_circle, color: Colors.green),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Text(
+                        _statusMessage,
+                        style: const TextStyle(color: Colors.green),
+                      ),
+                    ),
+                  ],
+                ),
+              )
+            else
+              // 進行中のメッセージ
+              Row(
+                children: [
+                  const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      _statusMessage,
+                      style: const TextStyle(fontSize: 14),
+                    ),
+                  ),
+                ],
+              ),
+
+            const SizedBox(height: 24),
+
+            // ボタン
+            if (_isCompleted || _hasError)
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: _hasError ? Colors.red : Colors.blue,
+                    foregroundColor: Colors.white,
+                  ),
+                  child: Text(_hasError ? '閉じる' : '完了'),
+                ),
+              )
+            else
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('キャンセル'),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/connection_page/provisioning_progress_dialog.dart
+++ b/lib/pages/connection_page/provisioning_progress_dialog.dart
@@ -30,7 +30,7 @@ enum ProvisioningStep {
     }
   }
 
-  /// ステップのインデクスを取得（プログレスバー用）
+  /// ステップのインデックスを取得（プログレスバー用）
   int get stepIndex {
     switch (this) {
       case ProvisioningStep.connecting:

--- a/lib/pages/connection_page/provisioning_progress_dialog.dart
+++ b/lib/pages/connection_page/provisioning_progress_dialog.dart
@@ -66,6 +66,7 @@ class _ProvisioningProgressDialogState
   final Provisioning _provisioning = Provisioning();
   StreamSubscription<dynamic>? _subscription;
   ProvisioningStep _currentStep = ProvisioningStep.connecting;
+  ProvisioningStep _lastStepBeforeError = ProvisioningStep.connecting;
   String _statusMessage = 'プロビジョニングを開始しています...';
 
   bool get _isCompleted => _currentStep == ProvisioningStep.complete;
@@ -114,8 +115,12 @@ class _ProvisioningProgressDialogState
           final status = data['status'] as String? ?? 'unknown';
           final message = data['message'] as String? ?? '';
 
+          final step = ProvisioningStep.fromStatus(status);
           setState(() {
-            _currentStep = ProvisioningStep.fromStatus(status);
+            if (step != ProvisioningStep.error) {
+              _lastStepBeforeError = step;
+            }
+            _currentStep = step;
             _statusMessage = message;
           });
         },
@@ -209,12 +214,18 @@ class _ProvisioningProgressDialogState
 
   /// ステップインジケーター
   Widget _buildStepIndicators() {
+    // エラー時はエラー前のステップを基準にする
+    final displayStep = _hasError ? _lastStepBeforeError : _currentStep;
+
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       children:
           _allSteps.map((step) {
-            final isActive = step.stepIndex <= _currentStep.stepIndex;
-            final isCurrent = step == _currentStep;
+            final isActive = step.stepIndex <= displayStep.stepIndex;
+            final isCurrent = step == displayStep;
+            // エラー時、エラーが起きたステップを赤で表示
+            final isErrorStep = _hasError && isCurrent;
+            final displayColor = isErrorStep ? Colors.red : step.color;
 
             return Expanded(
               child: Column(
@@ -226,16 +237,17 @@ class _ProvisioningProgressDialogState
                       shape: BoxShape.circle,
                       color:
                           isActive || isCurrent
-                              ? step.color.withValues(alpha: 0.2)
+                              ? displayColor.withValues(alpha: 0.2)
                               : Colors.grey[300],
                       border: Border.all(
-                        color: isActive || isCurrent ? step.color : Colors.grey,
+                        color:
+                            isActive || isCurrent ? displayColor : Colors.grey,
                         width: isCurrent ? 3 : 2,
                       ),
                     ),
                     child: Icon(
-                      step.icon,
-                      color: isActive || isCurrent ? step.color : Colors.grey,
+                      isErrorStep ? Icons.error : step.icon,
+                      color: isActive || isCurrent ? displayColor : Colors.grey,
                       size: 24,
                     ),
                   ),

--- a/lib/pages/connection_page/provisioning_progress_dialog.dart
+++ b/lib/pages/connection_page/provisioning_progress_dialog.dart
@@ -64,7 +64,7 @@ class ProvisioningProgressDialog extends StatefulWidget {
 class _ProvisioningProgressDialogState
     extends State<ProvisioningProgressDialog> {
   final Provisioning _provisioning = Provisioning();
-  StreamSubscription<dynamic>? _subscription;
+  StreamSubscription<Map<String, dynamic>>? _subscription;
   ProvisioningStep _currentStep = ProvisioningStep.connecting;
   ProvisioningStep _lastStepBeforeError = ProvisioningStep.connecting;
   String _statusMessage = 'プロビジョニングを開始しています...';
@@ -143,10 +143,10 @@ class _ProvisioningProgressDialogState
 
   /// 現在の進捗率を計算（0.0 ~ 1.0）
   double get _progressValue {
-    if (_hasError) return 0.0;
     if (_isCompleted) return 1.0;
 
-    final currentIndex = _currentStep.stepIndex;
+    final displayStep = _hasError ? _lastStepBeforeError : _currentStep;
+    final currentIndex = displayStep.stepIndex;
     if (currentIndex < 0) return 0.0;
 
     return (currentIndex + 1) / _allSteps.length;

--- a/lib/pages/connection_page/provisioning_progress_dialog.dart
+++ b/lib/pages/connection_page/provisioning_progress_dialog.dart
@@ -1,100 +1,34 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:soccer_app_flutter/features/platform_channels/provisioning.dart';
 
 /// プロビジョニングの進捗状態を表す列挙型
 enum ProvisioningStep {
-  connecting,
-  discovering,
-  identifying,
-  provisioning,
-  complete,
-  error;
+  connecting(0, '接続中', Icons.bluetooth, Colors.blue),
+  discovering(1, 'サービス検索中', Icons.bluetooth_searching, Colors.blue),
+  identifying(2, '識別中', Icons.search, Colors.blue),
+  provisioning(3, 'プロビジョニング中', Icons.settings, Colors.blue),
+  complete(4, '完了', Icons.check_circle, Colors.green),
+  error(-1, 'エラー', Icons.error, Colors.red);
+
+  const ProvisioningStep(
+    this.stepIndex,
+    this.displayName,
+    this.icon,
+    this.color,
+  );
+
+  final int stepIndex;
+  final String displayName;
+  final IconData icon;
+  final Color color;
 
   /// ステータス文字列から列挙型に変換
-  static ProvisioningStep fromStatus(String status) {
-    switch (status.toLowerCase()) {
-      case 'connecting':
-        return ProvisioningStep.connecting;
-      case 'discovering':
-        return ProvisioningStep.discovering;
-      case 'identifying':
-        return ProvisioningStep.identifying;
-      case 'provisioning':
-        return ProvisioningStep.provisioning;
-      case 'complete':
-        return ProvisioningStep.complete;
-      case 'error':
-        return ProvisioningStep.error;
-      default:
-        return ProvisioningStep.connecting;
-    }
-  }
-
-  /// ステップのインデックスを取得（プログレスバー用）
-  int get stepIndex {
-    switch (this) {
-      case ProvisioningStep.connecting:
-        return 0;
-      case ProvisioningStep.discovering:
-        return 1;
-      case ProvisioningStep.identifying:
-        return 2;
-      case ProvisioningStep.provisioning:
-        return 3;
-      case ProvisioningStep.complete:
-        return 4;
-      case ProvisioningStep.error:
-        return -1;
-    }
-  }
-
-  /// ステップの日本語名を取得
-  String get displayName {
-    switch (this) {
-      case ProvisioningStep.connecting:
-        return '接続中';
-      case ProvisioningStep.discovering:
-        return 'サービス検索中';
-      case ProvisioningStep.identifying:
-        return '識別中';
-      case ProvisioningStep.provisioning:
-        return 'プロビジョニング中';
-      case ProvisioningStep.complete:
-        return '完了';
-      case ProvisioningStep.error:
-        return 'エラー';
-    }
-  }
-
-  /// ステップのアイコンを取得
-  IconData get icon {
-    switch (this) {
-      case ProvisioningStep.connecting:
-        return Icons.bluetooth;
-      case ProvisioningStep.discovering:
-        return Icons.bluetooth_searching;
-      case ProvisioningStep.identifying:
-        return Icons.search;
-      case ProvisioningStep.provisioning:
-        return Icons.settings;
-      case ProvisioningStep.complete:
-        return Icons.check_circle;
-      case ProvisioningStep.error:
-        return Icons.error;
-    }
-  }
-
-  /// ステップの色を取得
-  Color get color {
-    switch (this) {
-      case ProvisioningStep.complete:
-        return Colors.green;
-      case ProvisioningStep.error:
-        return Colors.red;
-      default:
-        return Colors.blue;
-    }
-  }
+  static ProvisioningStep fromStatus(String status) => values.firstWhere(
+    (e) => e.name == status.toLowerCase(),
+    orElse: () => ProvisioningStep.connecting,
+  );
 }
 
 /// プロビジョニング進捗ダイアログ
@@ -130,10 +64,12 @@ class ProvisioningProgressDialog extends StatefulWidget {
 class _ProvisioningProgressDialogState
     extends State<ProvisioningProgressDialog> {
   final Provisioning _provisioning = Provisioning();
+  StreamSubscription<dynamic>? _subscription;
   ProvisioningStep _currentStep = ProvisioningStep.connecting;
   String _statusMessage = 'プロビジョニングを開始しています...';
-  bool _isCompleted = false;
-  bool _hasError = false;
+
+  bool get _isCompleted => _currentStep == ProvisioningStep.complete;
+  bool get _hasError => _currentStep == ProvisioningStep.error;
 
   // 全ステップ（エラーを除く）
   static const List<ProvisioningStep> _allSteps = [
@@ -150,6 +86,12 @@ class _ProvisioningProgressDialogState
     _startProvisioning();
   }
 
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    super.dispose();
+  }
+
   Future<void> _startProvisioning() async {
     try {
       // プロビジョニング開始
@@ -160,13 +102,12 @@ class _ProvisioningProgressDialogState
         setState(() {
           _currentStep = ProvisioningStep.error;
           _statusMessage = 'エラー: ${response['message']}';
-          _hasError = true;
         });
         return;
       }
 
       // プロビジョニングストリームを購読
-      _provisioning.provisioningStream.listen(
+      _subscription = _provisioning.provisioningStream.listen(
         (data) {
           if (!mounted) return;
 
@@ -176,12 +117,6 @@ class _ProvisioningProgressDialogState
           setState(() {
             _currentStep = ProvisioningStep.fromStatus(status);
             _statusMessage = message;
-
-            if (_currentStep == ProvisioningStep.complete) {
-              _isCompleted = true;
-            } else if (_currentStep == ProvisioningStep.error) {
-              _hasError = true;
-            }
           });
         },
         onError: (error) {
@@ -189,7 +124,6 @@ class _ProvisioningProgressDialogState
           setState(() {
             _currentStep = ProvisioningStep.error;
             _statusMessage = 'エラーが発生しました: $error';
-            _hasError = true;
           });
         },
       );
@@ -198,7 +132,6 @@ class _ProvisioningProgressDialogState
       setState(() {
         _currentStep = ProvisioningStep.error;
         _statusMessage = '予期しないエラー: $e';
-        _hasError = true;
       });
     }
   }
@@ -216,186 +149,192 @@ class _ProvisioningProgressDialogState
 
   @override
   Widget build(BuildContext context) {
-    return Dialog(
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.0)),
-      child: Padding(
-        padding: const EdgeInsets.all(24.0),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // タイトル
-            Text(
-              widget.deviceName,
-              style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'UUID: ${widget.deviceUuid}',
-              style: const TextStyle(fontSize: 12, color: Colors.grey),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 24),
+    return PopScope(
+      canPop: _isCompleted || _hasError,
+      child: Dialog(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16.0),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _buildHeader(),
+              const SizedBox(height: 24),
+              _buildProgressBar(),
+              const SizedBox(height: 16),
+              _buildStepIndicators(),
+              const SizedBox(height: 24),
+              _buildStatusMessage(),
+              const SizedBox(height: 24),
+              _buildActionButton(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 
-            // プログレスバー
-            LinearProgressIndicator(
-              value: _progressValue,
-              backgroundColor: Colors.grey[300],
-              valueColor: AlwaysStoppedAnimation<Color>(
-                _hasError ? Colors.red : Colors.blue,
-              ),
-              minHeight: 8,
-            ),
-            const SizedBox(height: 16),
+  /// ヘッダー（デバイス名・UUID）
+  Widget _buildHeader() {
+    return Column(
+      children: [
+        Text(
+          widget.deviceName,
+          style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'UUID: ${widget.deviceUuid}',
+          style: const TextStyle(fontSize: 12, color: Colors.grey),
+          textAlign: TextAlign.center,
+        ),
+      ],
+    );
+  }
 
-            // 現在のステップインジケーター
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children:
-                  _allSteps.map((step) {
-                    final isActive = step.stepIndex <= _currentStep.stepIndex;
-                    final isCurrent = step == _currentStep;
+  /// プログレスバー
+  Widget _buildProgressBar() {
+    return LinearProgressIndicator(
+      value: _progressValue,
+      backgroundColor: Colors.grey[300],
+      valueColor: AlwaysStoppedAnimation<Color>(
+        _hasError ? Colors.red : Colors.blue,
+      ),
+      minHeight: 8,
+    );
+  }
 
-                    return Expanded(
-                      child: Column(
-                        children: [
-                          Container(
-                            width: 48,
-                            height: 48,
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              color:
-                                  isActive || isCurrent
-                                      ? step.color.withValues(alpha: 0.2)
-                                      : Colors.grey[300],
-                              border: Border.all(
-                                color:
-                                    isActive || isCurrent
-                                        ? step.color
-                                        : Colors.grey,
-                                width: isCurrent ? 3 : 2,
-                              ),
-                            ),
-                            child: Icon(
-                              step.icon,
-                              color:
-                                  isActive || isCurrent
-                                      ? step.color
-                                      : Colors.grey,
-                              size: 24,
-                            ),
-                          ),
-                          const SizedBox(height: 8),
-                          Text(
-                            step.displayName,
-                            style: TextStyle(
-                              fontSize: 10,
-                              fontWeight:
-                                  isCurrent
-                                      ? FontWeight.bold
-                                      : FontWeight.normal,
-                              color:
-                                  isActive || isCurrent
-                                      ? Colors.black
-                                      : Colors.grey,
-                            ),
-                            textAlign: TextAlign.center,
-                          ),
-                        ],
-                      ),
-                    );
-                  }).toList(),
-            ),
-            const SizedBox(height: 24),
+  /// ステップインジケーター
+  Widget _buildStepIndicators() {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children:
+          _allSteps.map((step) {
+            final isActive = step.stepIndex <= _currentStep.stepIndex;
+            final isCurrent = step == _currentStep;
 
-            // エラー表示
-            if (_hasError)
-              Container(
-                padding: const EdgeInsets.all(12),
-                decoration: BoxDecoration(
-                  color: Colors.red[50],
-                  borderRadius: BorderRadius.circular(8),
-                  border: Border.all(color: Colors.red),
-                ),
-                child: Row(
-                  children: [
-                    const Icon(Icons.error, color: Colors.red),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: Text(
-                        _statusMessage,
-                        style: const TextStyle(color: Colors.red),
-                      ),
-                    ),
-                  ],
-                ),
-              )
-            else if (_isCompleted)
-              // 完了表示
-              Container(
-                padding: const EdgeInsets.all(12),
-                decoration: BoxDecoration(
-                  color: Colors.green[50],
-                  borderRadius: BorderRadius.circular(8),
-                  border: Border.all(color: Colors.green),
-                ),
-                child: Row(
-                  children: [
-                    const Icon(Icons.check_circle, color: Colors.green),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: Text(
-                        _statusMessage,
-                        style: const TextStyle(color: Colors.green),
-                      ),
-                    ),
-                  ],
-                ),
-              )
-            else
-              // 進行中のメッセージ
-              Row(
+            return Expanded(
+              child: Column(
                 children: [
-                  const SizedBox(
-                    width: 20,
-                    height: 20,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Text(
-                      _statusMessage,
-                      style: const TextStyle(fontSize: 14),
+                  Container(
+                    width: 48,
+                    height: 48,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color:
+                          isActive || isCurrent
+                              ? step.color.withValues(alpha: 0.2)
+                              : Colors.grey[300],
+                      border: Border.all(
+                        color: isActive || isCurrent ? step.color : Colors.grey,
+                        width: isCurrent ? 3 : 2,
+                      ),
                     ),
+                    child: Icon(
+                      step.icon,
+                      color: isActive || isCurrent ? step.color : Colors.grey,
+                      size: 24,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    step.displayName,
+                    style: TextStyle(
+                      fontSize: 10,
+                      fontWeight:
+                          isCurrent ? FontWeight.bold : FontWeight.normal,
+                      color: isActive || isCurrent ? Colors.black : Colors.grey,
+                    ),
+                    textAlign: TextAlign.center,
                   ),
                 ],
               ),
+            );
+          }).toList(),
+    );
+  }
 
-            const SizedBox(height: 24),
-
-            // ボタン
-            if (_isCompleted || _hasError)
-              SizedBox(
-                width: double.infinity,
-                child: ElevatedButton(
-                  onPressed: () => Navigator.of(context).pop(),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: _hasError ? Colors.red : Colors.blue,
-                    foregroundColor: Colors.white,
-                  ),
-                  child: Text(_hasError ? '閉じる' : '完了'),
-                ),
-              )
-            else
-              SizedBox(
-                width: double.infinity,
-                child: OutlinedButton(
-                  onPressed: () => Navigator.of(context).pop(),
-                  child: const Text('キャンセル'),
-                ),
+  /// ステータスメッセージ（エラー / 完了 / 進行中）
+  Widget _buildStatusMessage() {
+    if (_hasError) {
+      return Container(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: Colors.red[50],
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: Colors.red),
+        ),
+        child: Row(
+          children: [
+            const Icon(Icons.error, color: Colors.red),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                _statusMessage,
+                style: const TextStyle(color: Colors.red),
               ),
+            ),
           ],
         ),
+      );
+    }
+
+    if (_isCompleted) {
+      return Container(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: Colors.green[50],
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: Colors.green),
+        ),
+        child: Row(
+          children: [
+            const Icon(Icons.check_circle, color: Colors.green),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                _statusMessage,
+                style: const TextStyle(color: Colors.green),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Row(
+      children: [
+        const SizedBox(
+          width: 20,
+          height: 20,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Text(_statusMessage, style: const TextStyle(fontSize: 14)),
+        ),
+      ],
+    );
+  }
+
+  /// アクションボタン（完了/閉じる）
+  Widget _buildActionButton() {
+    if (!_isCompleted && !_hasError) {
+      return const SizedBox.shrink();
+    }
+
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton(
+        onPressed: () => Navigator.of(context).pop(),
+        style: ElevatedButton.styleFrom(
+          backgroundColor: _hasError ? Colors.red : Colors.blue,
+          foregroundColor: Colors.white,
+        ),
+        child: Text(_hasError ? '閉じる' : '完了'),
       ),
     );
   }

--- a/lib/pages/connection_page/provisioning_progress_dialog.dart
+++ b/lib/pages/connection_page/provisioning_progress_dialog.dart
@@ -27,7 +27,7 @@ enum ProvisioningStep {
   /// ステータス文字列から列挙型に変換
   static ProvisioningStep fromStatus(String status) => values.firstWhere(
     (e) => e.name == status.toLowerCase(),
-    orElse: () => ProvisioningStep.connecting,
+    orElse: () => ProvisioningStep.error,
   );
 }
 
@@ -49,11 +49,13 @@ enum ProvisioningStep {
 class ProvisioningProgressDialog extends StatefulWidget {
   final String deviceName;
   final String deviceUuid;
+  final bool isMockDevice;
 
   const ProvisioningProgressDialog({
     super.key,
     required this.deviceName,
     required this.deviceUuid,
+    this.isMockDevice = false,
   });
 
   @override
@@ -73,23 +75,15 @@ class _ProvisioningProgressDialogState
   bool get _hasError => _currentStep == ProvisioningStep.error;
 
   // 全ステップ（エラーを除く）
-  static const List<ProvisioningStep> _allSteps = [
-    ProvisioningStep.connecting,
-    ProvisioningStep.discovering,
-    ProvisioningStep.identifying,
-    ProvisioningStep.provisioning,
-    ProvisioningStep.complete,
-  ];
-
-  final bool _isDebugMode = const bool.fromEnvironment(
-    'DEBUG',
-    defaultValue: false,
-  );
+  static final List<ProvisioningStep> _allSteps =
+      ProvisioningStep.values
+          .where((e) => e != ProvisioningStep.error)
+          .toList();
 
   @override
   void initState() {
     super.initState();
-    if (_isDebugMode) {
+    if (widget.isMockDevice) {
       _startProvisioningDebug();
     } else {
       _startProvisioning();

--- a/lib/pages/connection_page/provisioning_progress_dialog.dart
+++ b/lib/pages/connection_page/provisioning_progress_dialog.dart
@@ -81,16 +81,49 @@ class _ProvisioningProgressDialogState
     ProvisioningStep.complete,
   ];
 
+  final bool _isDebugMode = const bool.fromEnvironment(
+    'DEBUG',
+    defaultValue: false,
+  );
+
   @override
   void initState() {
     super.initState();
-    _startProvisioning();
+    if (_isDebugMode) {
+      _startProvisioningDebug();
+    } else {
+      _startProvisioning();
+    }
   }
 
   @override
   void dispose() {
     _subscription?.cancel();
     super.dispose();
+  }
+
+  /// デバッグ用: 各ステップを2秒間隔で擬似的に進行させる
+  Future<void> _startProvisioningDebug() async {
+    const steps = [
+      ('connecting', '接続中...'),
+      ('discovering', 'サービス検索中...'),
+      ('identifying', '識別中...'),
+      ('provisioning', 'プロビジョニング中...'),
+      ('complete', 'プロビジョニング完了！'),
+    ];
+
+    for (final (status, message) in steps) {
+      await Future.delayed(const Duration(seconds: 2));
+      if (!mounted) return;
+      final step = ProvisioningStep.fromStatus(status);
+      setState(() {
+        if (step != ProvisioningStep.error) {
+          _lastStepBeforeError = step;
+        }
+        _currentStep = step;
+        _statusMessage = message;
+      });
+    }
   }
 
   Future<void> _startProvisioning() async {


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

### 概要 & 関連資料
<!-- issue番号を # の後に入れると PR merge 時に close される -->
- close #95 

### 変更内容
<!-- どのような変更をしたか -->
<!-- ex.) ユーザーがアプリを楽しく使えるようにタスク完了時にアニメーションをつけた -->
- BLEデバイスのプロビジョニング進捗表示をポップアップ形式からステップ表示付きプログレスバー形式に変更
- プロビジョニングの各ステップ（接続中，サービス検索中，識別中，プロビジョニング中，完了）を視覚的に表示
- エラー発生時は赤色で明示的に表示し，ユーザーに状態をわかりやすく通知

### 影響範囲
<!-- どの画面に影響するか -->
<!-- ex.) タスク一覧画面 -->
- 接続ページ（ConnectionPage）
- デバイスリスト表示画面（DiscoveredDeviceList）
- 新規追加：プロビジョニング進捗ダイアログ（ProvisioningProgressDialog）

### 備考
<!-- レビューに関してのコメントなど -->
<!-- ex.) ダークモードへの対応はできてないが、後で対応するのでスルーして下さい -->
- プロビジョニング中はダイアログ外をタップしても閉じられないようにしています（barrierDismissible: false）（Android戻るボタン制御）（進行中はボタン非表示（キャンセル不可））
- ステップ表示は5段階（接続中→サービス検索中→識別中→プロビジョニング中→完了）で構成
- Swift側の`ProvisioningStatus`列挙型（connecting, discovering, identifying, provisioning, complete, error）に対応
- デバッグモックアップ対応

### セルフチェック
- [ ] 環境変数などがPRに含まれていないか

<!-- I want to review in Japanese. -->
