### PR TITLE
【feat】Provisioning後の Configuration / Subscription / Publication 設定

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -30,12 +30,13 @@ enum MeshState: String {
             stateQueue.async { [weak self] in
                 guard let self = self else { return }
                 let oldValue = self._meshState
-                guard oldValue != newValue else {
-                    return
-                }
+                guard oldValue != newValue else { return }
                 
+                // Write under stateQueue to maintain thread safety
+                self._meshState = newValue
+                
+                // Notify via EventChannel and timers on main thread
                 DispatchQueue.main.async {
-                    self._meshState = newValue
                     let previousState = oldValue.rawValue
                     let nextState = newValue.rawValue
                     let isMain = Thread.isMainThread ? "main" : "background"
@@ -180,11 +181,7 @@ enum MeshState: String {
         connection!.dataDelegate = meshNetworkManager
         meshNetworkManager.transmitter = connection
 
-        do {
-            try connection!.open()
-        } catch {
-            print("Failed to open network connection: \(error)")
-        }
+        connection!.open()
     }
 
     private func initializeProvisioningService() {
@@ -218,10 +215,9 @@ enum MeshState: String {
     private func startProxyConnectionTimer() {
         stopProxyConnectionTimer()
         proxyConnectionTimer = Timer.scheduledTimer(withTimeInterval: proxyConnectionTimeout, repeats: false) { [weak self] _ in
-            guard let self = self, self._meshState == .waitProxyConnection else { return }
+            guard let self = self, self.meshState == .waitProxyConnection else { return }
             print("[ProxyTimeout] GATT Proxy connection timed out.")
             self.connection?.close()
-            self._meshState = .complete
             MeshNetworkEventStreamHandler.shared.sendEvent(status: .error, data: [
                 "eventType": "configuration",
                 "message": "Proxyスキャンタイムアウト"
@@ -327,26 +323,29 @@ extension AppDelegate: ProxyFilterDelegate {
                     return
                 }
                 
-                let infoDetail = "[ProxyFilterDelegate] Found target address \(targetAddress) in filter, triggering configureNode"
+                let infoDetail = "[ProxyFilterDelegate] Found target address \(targetAddress) in filter, triggering configureNode in 1.0s"
                 MeshTrace.log(
                     traceId: traceIdStr,
                     step: "PROXY_FILTER",
-                    event: "TRIGGER_CONFIGURE_NODE",
+                    event: "TRIGGER_CONFIGURE_NODE_DELAY",
                     node: "\(targetAddress)",
                     state: meshState.rawValue,
                     detail: infoDetail
                 )
-                let result = ConfigurationService.shared.configureNode(unicastAddress: targetAddress)
                 
-                let resultDetail = "[ProxyFilterDelegate] configureNode triggered: \(result.isSuccess) - \(result.message)"
-                MeshTrace.log(
-                    traceId: traceIdStr,
-                    step: "PROXY_FILTER",
-                    event: "CONFIGURE_NODE_RESULT",
-                    node: "\(targetAddress)",
-                    state: meshState.rawValue,
-                    detail: resultDetail
-                )
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                    let result = ConfigurationService.shared.configureNode(unicastAddress: targetAddress)
+                    
+                    let resultDetail = "[ProxyFilterDelegate] configureNode triggered: \(result.isSuccess) - \(result.message)"
+                    MeshTrace.log(
+                        traceId: traceIdStr,
+                        step: "PROXY_FILTER",
+                        event: "CONFIGURE_NODE_RESULT",
+                        node: "\(targetAddress)",
+                        state: self.meshState.rawValue,
+                        detail: resultDetail
+                    )
+                }
             }
         }
     }
@@ -371,11 +370,7 @@ extension AppDelegate: BearerDelegate {
         if meshState == .waitComposition || meshState == .configuring || meshState == .proxyConnected || meshState == .waitProxyConnection {
             meshState = .waitProxyConnection
             if let connection = connection {
-                do {
-                    try connection.open()
-                } catch {
-                    print("Failed to reopen connection: \(error.localizedDescription)")
-                }
+                connection.open()
             }
         }
     }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -27,39 +27,41 @@ enum MeshState: String {
             return stateQueue.sync { _meshState }
         }
         set {
-            stateQueue.async { [weak self] in
+            var oldValue: MeshState!
+            stateQueue.sync {
+                oldValue = _meshState
+                if oldValue != newValue {
+                    _meshState = newValue
+                }
+            }
+            
+            guard oldValue != newValue else { return }
+            
+            // Notify via EventChannel and timers on main thread
+            DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
-                let oldValue = self._meshState
-                guard oldValue != newValue else { return }
+                let previousState = oldValue.rawValue
+                let nextState = newValue.rawValue
+                let isMain = Thread.isMainThread ? "main" : "background"
+                let stackTrace = Thread.callStackSymbols.prefix(5).joined(separator: " | ")
+                let nodeRef = ConfigurationService.shared.currentTargetAddress != nil ? "\(ConfigurationService.shared.currentTargetAddress!)" : "nil"
+                let traceIdStr = ConfigurationService.shared.configTraceId?.uuidString ?? "N/A"
                 
-                // Write under stateQueue to maintain thread safety
-                self._meshState = newValue
+                MeshTrace.log(
+                    traceId: traceIdStr,
+                    step: "STATE_TRANSITION",
+                    event: "CHANGE",
+                    node: nodeRef,
+                    state: nextState,
+                    detail: "Transition: \(previousState) -> \(nextState) | Thread: \(isMain) | Stack: \(stackTrace)"
+                )
                 
-                // Notify via EventChannel and timers on main thread
-                DispatchQueue.main.async {
-                    let previousState = oldValue.rawValue
-                    let nextState = newValue.rawValue
-                    let isMain = Thread.isMainThread ? "main" : "background"
-                    let stackTrace = Thread.callStackSymbols.prefix(5).joined(separator: " | ")
-                    let nodeRef = ConfigurationService.shared.currentTargetAddress != nil ? "\(ConfigurationService.shared.currentTargetAddress!)" : "nil"
-                    let traceIdStr = ConfigurationService.shared.configTraceId?.uuidString ?? "N/A"
-                    
-                    MeshTrace.log(
-                        traceId: traceIdStr,
-                        step: "STATE_TRANSITION",
-                        event: "CHANGE",
-                        node: nodeRef,
-                        state: nextState,
-                        detail: "Transition: \(previousState) -> \(nextState) | Thread: \(isMain) | Stack: \(stackTrace)"
-                    )
-                    
-                    self.sendFlutterMeshStateEvent(state: newValue)
-                    
-                    if newValue == .waitProxyConnection {
-                        self.startProxyConnectionTimer()
-                    } else if newValue == .proxyConnected {
-                        self.stopProxyConnectionTimer()
-                    }
+                self.sendFlutterMeshStateEvent(state: newValue)
+                
+                if newValue == .waitProxyConnection {
+                    self.startProxyConnectionTimer()
+                } else if newValue == .proxyConnected {
+                    self.stopProxyConnectionTimer()
                 }
             }
         }
@@ -365,6 +367,11 @@ extension AppDelegate: BearerDelegate {
         // SDK内部のproxyNetworkKeyをnilにリセットし、次の接続で
         // newProxyDidConnect()が確実に呼ばれるようにする
         meshNetworkManager.proxyFilter.proxyDidDisconnect()
+        
+        if let connection = connection, connection.isExplicitlyClosing {
+            print("[ProxyDelegate] Connection was explicitly closed. Skipping automatic reconnection.")
+            return
+        }
         
         // プロビジョニング中などの意図的な切断時に、勝手にProxy接続を再開しないようにする
         if meshState == .waitComposition || meshState == .configuring || meshState == .proxyConnected || meshState == .waitProxyConnection {

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -53,6 +53,12 @@ enum MeshState: String {
                     )
                     
                     self.sendFlutterMeshStateEvent(state: newValue)
+                    
+                    if newValue == .waitProxyConnection {
+                        self.startProxyConnectionTimer()
+                    } else if newValue == .proxyConnected {
+                        self.stopProxyConnectionTimer()
+                    }
                 }
             }
         }
@@ -71,6 +77,10 @@ enum MeshState: String {
     var compositionDataRetries = 0
     let maxCompositionDataRetries = 3
     let retryTimeInterval = 5.0
+
+    // Proxy Connection Timeout
+    var proxyConnectionTimer: Timer?
+    let proxyConnectionTimeout = 30.0
 
     // MARK: - Application Lifecycle
 
@@ -203,6 +213,25 @@ enum MeshState: String {
                 "message": "State transitioned to \(state.rawValue)"
             ]
         )
+    }
+
+    private func startProxyConnectionTimer() {
+        stopProxyConnectionTimer()
+        proxyConnectionTimer = Timer.scheduledTimer(withTimeInterval: proxyConnectionTimeout, repeats: false) { [weak self] _ in
+            guard let self = self, self._meshState == .waitProxyConnection else { return }
+            print("[ProxyTimeout] GATT Proxy connection timed out.")
+            self.connection?.close()
+            self._meshState = .complete
+            MeshNetworkEventStreamHandler.shared.sendEvent(status: .error, data: [
+                "eventType": "configuration",
+                "message": "Proxyスキャンタイムアウト"
+            ])
+        }
+    }
+
+    private func stopProxyConnectionTimer() {
+        proxyConnectionTimer?.invalidate()
+        proxyConnectionTimer = nil
     }
 }
 

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -2,10 +2,61 @@ import Flutter
 import NordicMesh
 import UIKit
 
+enum MeshState: String {
+    case provisioning = "PROVISIONING"
+    case provisioningComplete = "PROVISIONING_COMPLETE"
+    case waitProxyConnection = "WAIT_PROXY_CONNECTION"
+    case proxyConnected = "PROXY_CONNECTED"
+    case waitComposition = "WAIT_COMPOSITION"
+    case configuring = "CONFIGURING"
+    case complete = "COMPLETE"
+    case subscription = "SUBSCRIPTION"
+    case publication = "PUBLICATION"
+}
+
 @main
 @objc class AppDelegate: FlutterAppDelegate {
 
     // MARK: - Properties
+ 
+    private let stateQueue = DispatchQueue(label: "com.soccerapp.mesh.state")
+    private var _meshState: MeshState = .complete
+    
+    var meshState: MeshState {
+        get {
+            return stateQueue.sync { _meshState }
+        }
+        set {
+            stateQueue.async { [weak self] in
+                guard let self = self else { return }
+                let oldValue = self._meshState
+                guard oldValue != newValue else {
+                    return
+                }
+                
+                DispatchQueue.main.async {
+                    self._meshState = newValue
+                    let previousState = oldValue.rawValue
+                    let nextState = newValue.rawValue
+                    let isMain = Thread.isMainThread ? "main" : "background"
+                    let stackTrace = Thread.callStackSymbols.prefix(5).joined(separator: " | ")
+                    let nodeRef = ConfigurationService.shared.currentTargetAddress != nil ? "\(ConfigurationService.shared.currentTargetAddress!)" : "nil"
+                    let traceIdStr = ConfigurationService.shared.configTraceId?.uuidString ?? "N/A"
+                    
+                    MeshTrace.log(
+                        traceId: traceIdStr,
+                        step: "STATE_TRANSITION",
+                        event: "CHANGE",
+                        node: nodeRef,
+                        state: nextState,
+                        detail: "Transition: \(previousState) -> \(nextState) | Thread: \(isMain) | Stack: \(stackTrace)"
+                    )
+                    
+                    self.sendFlutterMeshStateEvent(state: newValue)
+                }
+            }
+        }
+    }
 
     // Manager Instances
     var meshNetworkManager: MeshNetworkManager!
@@ -52,6 +103,7 @@ import UIKit
 
     private func initializeMeshNetworkManager() {
         meshNetworkManager = MeshNetworkManager()
+        meshNetworkManager.proxyFilter.delegate = self
         meshNetworkManager.networkParameters = .default
 
         do {
@@ -114,6 +166,7 @@ import UIKit
         meshNetworkManager.localElements = [primaryElement]
 
         connection = NetworkConnection(to: meshNetwork)
+        connection!.delegate = self
         connection!.dataDelegate = meshNetworkManager
         meshNetworkManager.transmitter = connection
 
@@ -139,6 +192,17 @@ import UIKit
             provisioningService: provisioningService,
         )
         flutterChannelManager.setupChannels()
+    }
+
+    private func sendFlutterMeshStateEvent(state: MeshState) {
+        MeshNetworkEventStreamHandler.shared.sendEvent(
+            status: .processing,
+            data: [
+                "eventType": "meshStateChanged",
+                "meshState": state.rawValue,
+                "message": "State transitioned to \(state.rawValue)"
+            ]
+        )
     }
 }
 
@@ -168,3 +232,124 @@ extension MeshNetworkManager {
         }
     }
 }
+
+extension AppDelegate: ProxyFilterDelegate {
+    func proxyFilterUpdated(type: ProxyFilerType, addresses: Set<Address>) {
+        ConfigurationService.shared.proxyFilterUpdatedCount += 1
+        let count = ConfigurationService.shared.proxyFilterUpdatedCount
+        let targetAddress = ConfigurationService.shared.currentTargetAddress
+        let targetMatch = targetAddress != nil ? addresses.contains(targetAddress!) : false
+        let traceIdStr = ConfigurationService.shared.configTraceId?.uuidString ?? "N/A"
+        
+        let detail = "Proxy filter updated count: \(count). Type: \(type), Addresses: \(addresses). TargetAddress: \(targetAddress != nil ? String(targetAddress!) : "nil"). Match: \(targetMatch)"
+        
+        MeshTrace.log(
+            traceId: traceIdStr,
+            step: "PROXY_FILTER",
+            event: "UPDATED",
+            node: targetAddress != nil ? "\(targetAddress!)" : "nil",
+            state: meshState.rawValue,
+            detail: detail
+        )
+        
+        if meshState == .proxyConnected {
+            guard let targetAddress = ConfigurationService.shared.currentTargetAddress else {
+                let errDetail = "[ProxyFilterDelegate] Error: currentTargetAddress is nil"
+                MeshTrace.log(
+                    traceId: traceIdStr,
+                    step: "PROXY_FILTER",
+                    event: "ERROR",
+                    node: "nil",
+                    state: meshState.rawValue,
+                    detail: errDetail
+                )
+                return
+            }
+            if !ConfigurationService.shared.isConfiguring {
+                // ターゲットがまだフィルターに入っていない場合
+                if !addresses.contains(targetAddress) {
+                    // SDKのデフォルト設定（1 や 65535 の追加）が終わっているか確認する
+                    let localAddress = meshNetworkManager.meshNetwork?.localProvisioner?.unicastAddress ?? 1
+                    
+                    if addresses.contains(localAddress) || addresses.contains(.allProxies) {
+                        // デフォルト設定が完了していれば、ここで安全にターゲットを追加！
+                        let waitDetail = "[ProxyFilterDelegate] Default filter setup complete. Now adding target \(targetAddress)"
+                        MeshTrace.log(
+                            traceId: traceIdStr,
+                            step: "PROXY_FILTER",
+                            event: "ADDING_TARGET",
+                            node: "\(targetAddress)",
+                            state: meshState.rawValue,
+                            detail: waitDetail
+                        )
+                        meshNetworkManager.proxyFilter.add(address: targetAddress)
+                    } else {
+                        // まだ空っぽ（初期化中）の場合は待つ
+                        let waitDetail = "[ProxyFilterDelegate] Filter initializing... waiting."
+                        MeshTrace.log(
+                            traceId: traceIdStr,
+                            step: "PROXY_FILTER",
+                            event: "WAITING_FOR_INITIALIZATION",
+                            node: "\(targetAddress)",
+                            state: meshState.rawValue,
+                            detail: waitDetail
+                        )
+                    }
+                    return
+                }
+                
+                let infoDetail = "[ProxyFilterDelegate] Found target address \(targetAddress) in filter, triggering configureNode"
+                MeshTrace.log(
+                    traceId: traceIdStr,
+                    step: "PROXY_FILTER",
+                    event: "TRIGGER_CONFIGURE_NODE",
+                    node: "\(targetAddress)",
+                    state: meshState.rawValue,
+                    detail: infoDetail
+                )
+                let result = ConfigurationService.shared.configureNode(unicastAddress: targetAddress)
+                
+                let resultDetail = "[ProxyFilterDelegate] configureNode triggered: \(result.isSuccess) - \(result.message)"
+                MeshTrace.log(
+                    traceId: traceIdStr,
+                    step: "PROXY_FILTER",
+                    event: "CONFIGURE_NODE_RESULT",
+                    node: "\(targetAddress)",
+                    state: meshState.rawValue,
+                    detail: resultDetail
+                )
+            }
+        }
+    }
+}
+
+extension AppDelegate: BearerDelegate {
+    func bearerDidOpen(_ bearer: Bearer) {
+        print("[ProxyDelegate] bearerDidOpen callback. Current state: \(meshState.rawValue)")
+        if meshState == .waitProxyConnection {
+            meshState = .proxyConnected
+        }
+    }
+
+    func bearer(_ bearer: Bearer, didClose error: Error?) {
+        print("[ProxyDelegate] bearerDidClose callback. Current state: \(meshState.rawValue)")
+        
+        // SDK内部のproxyNetworkKeyをnilにリセットし、次の接続で
+        // newProxyDidConnect()が確実に呼ばれるようにする
+        meshNetworkManager.proxyFilter.proxyDidDisconnect()
+        
+        // プロビジョニング中などの意図的な切断時に、勝手にProxy接続を再開しないようにする
+        if meshState == .waitComposition || meshState == .configuring || meshState == .proxyConnected || meshState == .waitProxyConnection {
+            meshState = .waitProxyConnection
+            if let connection = connection {
+                do {
+                    try connection.open()
+                } catch {
+                    print("Failed to reopen connection: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+}
+
+

--- a/ios/Runner/Bluetooth/AppDelegate+MeshNetworkDelegate.swift
+++ b/ios/Runner/Bluetooth/AppDelegate+MeshNetworkDelegate.swift
@@ -16,26 +16,107 @@ extension AppDelegate: MeshNetworkDelegate {
         sentFrom source: NordicMesh.Address,
         to destination: NordicMesh.MeshAddress
     ) {
+        // ノード解決ログ（受信メッセージのソースアドレスを解決する際）
+        ConfigurationService.shared.logNodeResolution(
+            forAddress: source,
+            step: "NODE_RESOLUTION",
+            event: "MESSAGE_RECEIVED"
+        )
+
+        let traceIdStr = ConfigurationService.shared.configTraceId?.uuidString ?? "N/A"
+        let receivedType = "\(type(of: message))"
+        let expectedAck = ConfigurationService.shared.pendingAckMessage
+        
+        var match = false
+        var durationMs: Double = -1.0
+        
+        if let pendingAck = expectedAck {
+            let isAppKeyMatch = (pendingAck == "ConfigAppKeyAdd" && receivedType == "ConfigAppKeyStatus")
+            let isCompositionMatch = (pendingAck == "ConfigCompositionDataGet" && receivedType == "ConfigCompositionDataStatus")
+            let isModelBindMatch = (pendingAck == "ConfigModelAppBind" && receivedType == "ConfigModelAppStatus")
+            let isSubMatch = (pendingAck == "ConfigModelSubscriptionAdd" && receivedType == "ConfigModelSubscriptionStatus")
+            let isPubMatch = (pendingAck == "ConfigModelPublicationSet" && receivedType == "ConfigModelPublicationStatus")
+            
+            if isAppKeyMatch || isCompositionMatch || isModelBindMatch || isSubMatch || isPubMatch {
+                match = true
+            }
+            
+            if let sentTime = ConfigurationService.shared.pendingAckSentTime {
+                durationMs = Date().timeIntervalSince(sentTime) * 1000.0
+            }
+        }
+        
+        let ackDetail = "Received \(receivedType) from \(source). PendingAck: \(expectedAck ?? "None"). Match: \(match). Duration: \(durationMs >= 0 ? String(format: "%.1fms", durationMs) : "N/A")"
+        MeshTrace.log(
+            traceId: traceIdStr,
+            step: "ACK_TRACKING",
+            event: "RECEIVED",
+            node: "\(source)",
+            state: meshState.rawValue,
+            detail: ackDetail
+        )
+        
+        if match {
+            ConfigurationService.shared.pendingAckMessage = nil
+            ConfigurationService.shared.pendingAckSentTime = nil
+        }
+
         // nodeを探す
         guard let node = manager.meshNetwork?.node(withAddress: source) else {
-            print("Couldn't fild node with address \(source)")
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "DELEGATE_RECEIVE",
+                event: "NODE_NOT_FOUND_ERROR",
+                node: "\(source)",
+                state: meshState.rawValue,
+                detail: "Couldn't find node with address \(source) in meshNetwork.nodes"
+            )
             return
         }
 
         switch message {
         case is ConfigCompositionDataStatus:
-            print("Received Composition Data from \(source)")
-            // タイマーを停止
+            guard meshState == .waitComposition else { return }
+            
+            let statusDetail = "Received Composition Data Status from \(source). Invaliding timer."
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "COMPOSITION_DATA",
+                event: "STATUS_RECEIVED",
+                node: "\(source)",
+                state: meshState.rawValue,
+                detail: statusDetail
+            )
+            
             compositionDataTimer?.invalidate()
             compositionDataTimer = nil
-            // 構成データ取得後、モデルバインドに進む
+            
+            ConfigurationService.shared.lastReceivedEvent = "ConfigCompositionDataStatus Received"
+            ConfigurationService.shared.expectedNextEvent = "ConfigModelAppStatus"
+            ConfigurationService.shared.expectedDelegate = "ConfigModelAppStatus"
+            
             handleCompositionDataStatus(
                 node: node,
                 manager: manager
             )
 
         case let appKeyStatus as ConfigAppKeyStatus:
-            print("Received AppKeyStatus: \(appKeyStatus.status)")
+            guard meshState == .configuring else { return }
+            
+            let statusDetail = "Received AppKeyStatus: \(appKeyStatus.status) from \(source)"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "APP_KEY_ADD",
+                event: "STATUS_RECEIVED",
+                node: "\(source)",
+                state: meshState.rawValue,
+                detail: statusDetail
+            )
+            
+            ConfigurationService.shared.lastReceivedEvent = "ConfigAppKeyStatus Received"
+            ConfigurationService.shared.expectedNextEvent = "ConfigCompositionDataStatus"
+            ConfigurationService.shared.expectedDelegate = "ConfigCompositionDataStatus"
+            
             handleAppKeyStatus(
                 appKeyStatus: appKeyStatus,
                 manager: manager,
@@ -43,7 +124,36 @@ extension AppDelegate: MeshNetworkDelegate {
             )
 
         case let modelStatus as ConfigModelAppStatus:
-            print("Recieved ConfigModelAppStatus: \(modelStatus.status)")
+            guard meshState == .configuring else { return }
+            
+            let statusDetail = "Received ConfigModelAppStatus: \(modelStatus.status) from \(source)"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "MODEL_APP_BIND",
+                event: "STATUS_RECEIVED",
+                node: "\(source)",
+                state: meshState.rawValue,
+                detail: statusDetail
+            )
+            
+            // ローカル（アドレス1）へのバインドに対する応答は無視し、リモートノードからの応答のみを処理する
+            if source == Address(0x0001) {
+                let localDetail = "Received local Client Model AppBind status. Skipping state transition."
+                MeshTrace.log(
+                    traceId: traceIdStr,
+                    step: "MODEL_APP_BIND",
+                    event: "LOCAL_STATUS_IGNORED",
+                    node: "\(source)",
+                    state: meshState.rawValue,
+                    detail: localDetail
+                )
+                return
+            }
+            
+            ConfigurationService.shared.lastReceivedEvent = "ConfigModelAppStatus Received"
+            ConfigurationService.shared.expectedNextEvent = "ConfigModelSubscriptionStatus"
+            ConfigurationService.shared.expectedDelegate = "ConfigModelSubscriptionStatus"
+            
             Task {
                 await handleModelAppStatus(
                     modelAppStatus: modelStatus,
@@ -53,40 +163,135 @@ extension AppDelegate: MeshNetworkDelegate {
             }
 
         case let configSubscriptionState as ConfigModelSubscriptionStatus:
+            guard meshState == .subscription, !ConfigurationService.shared.isSubscribed else { return }
+            ConfigurationService.shared.isSubscribed = true
+            
+            ConfigurationService.shared.lastReceivedEvent = "ConfigModelSubscriptionStatus Received"
+            ConfigurationService.shared.expectedNextEvent = "ConfigModelPublicationStatus"
+            ConfigurationService.shared.expectedDelegate = "ConfigModelPublicationStatus"
+            
             if configSubscriptionState.isSuccess {
+                let statusDetail = "Successfully subscribe model for \(source)"
+                MeshTrace.log(
+                    traceId: traceIdStr,
+                    step: "SUBSCRIPTION",
+                    event: "SUCCESS",
+                    node: "\(source)",
+                    state: meshState.rawValue,
+                    detail: statusDetail
+                )
+                
                 sendFlutterEvent(
                     status: .success,
                     message: "Successfully subscribe model",
                     eventType: "subscription"
                 )
+                
+                if !ConfigurationService.shared.isPublished {
+                    meshState = .publication
+                    let result = ConfigurationService.shared.setPublication(withAddress: source)
+                    
+                    let triggerDetail = "Publication triggered: \(result.isSuccess) - \(result.message)"
+                    MeshTrace.log(
+                        traceId: traceIdStr,
+                        step: "PUBLICATION",
+                        event: "TRIGGER",
+                        node: "\(source)",
+                        state: meshState.rawValue,
+                        detail: triggerDetail
+                    )
+                }
             } else {
+                let statusDetail = "Failed to subscribe model: \(configSubscriptionState.message) for \(source)"
+                MeshTrace.log(
+                    traceId: traceIdStr,
+                    step: "SUBSCRIPTION",
+                    event: "FAILURE",
+                    node: "\(source)",
+                    state: meshState.rawValue,
+                    detail: statusDetail
+                )
+                
                 sendFlutterEvent(
                     status: .error,
-                    message:
-                        "Failed to subscribe model: \(configSubscriptionState.message)",
+                    message: "Failed to subscribe model: \(configSubscriptionState.message)",
                     eventType: "subscription"
                 )
             }
 
         case let configPublicationStatus as ConfigModelPublicationStatus:
+            guard meshState == .publication else { return }
+            
+            ConfigurationService.shared.lastReceivedEvent = "ConfigModelPublicationStatus Received"
+            ConfigurationService.shared.expectedNextEvent = "Flow Complete"
+            ConfigurationService.shared.expectedDelegate = "None"
+            ConfigurationService.shared.markConfigurationComplete() // 正常終了: isConfiguring リセット + Watchdog停止
+            
             if configPublicationStatus.status == .success {
+                let statusDetail = "Successfully publish model for \(source)"
+                MeshTrace.log(
+                    traceId: traceIdStr,
+                    step: "PUBLICATION",
+                    event: "SUCCESS",
+                    node: "\(source)",
+                    state: meshState.rawValue,
+                    detail: statusDetail
+                )
+                
                 sendFlutterEvent(
                     status: .success,
                     message: "Successfully publish model",
                     eventType: "publication"
                 )
             } else {
+                let statusDetail = "Failed to publish model: \(configPublicationStatus.message) for \(source)"
+                MeshTrace.log(
+                    traceId: traceIdStr,
+                    step: "PUBLICATION",
+                    event: "FAILURE",
+                    node: "\(source)",
+                    state: meshState.rawValue,
+                    detail: statusDetail
+                )
+                
                 sendFlutterEvent(
                     status: .error,
-                    message:
-                        "Failed to publish model: \(configPublicationStatus.message)",
+                    message: "Failed to publish model: \(configPublicationStatus.message)",
                     eventType: "publication"
                 )
             }
 
+        case is ConfigNodeResetStatus:
+            let statusDetail = "Received ConfigNodeResetStatus from \(source). Removing node from database."
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "RESET_NODE",
+                event: "SUCCESS",
+                node: "\(source)",
+                state: meshState.rawValue,
+                detail: statusDetail
+            )
+            
+            if let meshNetwork = manager.meshNetwork {
+                meshNetwork.remove(node: node)
+                _ = manager.save()
+            }
+            sendFlutterEvent(
+                status: .success,
+                message: "Node successfully reset and removed from database",
+                eventType: "resetNode"
+            )
+
         default:
-            print("Message type : \(type(of: message))")
-            print(message)
+            let detailUnknown = "Received unknown message type: \(receivedType)"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "DELEGATE_RECEIVE",
+                event: "UNKNOWN_MESSAGE",
+                node: "\(source)",
+                state: meshState.rawValue,
+                detail: detailUnknown
+            )
         }
     }
 
@@ -95,15 +300,33 @@ extension AppDelegate: MeshNetworkDelegate {
         manager: MeshNetworkManager,
         node: Node
     ) {
+        let traceIdStr = ConfigurationService.shared.configTraceId?.uuidString ?? "N/A"
         if appKeyStatus.status == .success {
-            print("AppKey added successfully.")
-            // AppKeyの追加成功後，Composition Dataをリクエスト
+            let detail = "AppKey added successfully. Transitioning to waitComposition."
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "APP_KEY_ADD",
+                event: "STATUS_SUCCESS",
+                node: "\(node.primaryUnicastAddress)",
+                state: meshState.rawValue,
+                detail: detail
+            )
+            meshState = .waitComposition
             sendCompositionDataRequest(to: node)
         } else {
+            let detail = "Failed to add AppKey: \(appKeyStatus.status.debugDescription)"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "APP_KEY_ADD",
+                event: "STATUS_FAILURE",
+                node: "\(node.primaryUnicastAddress)",
+                state: meshState.rawValue,
+                detail: detail
+            )
+            ConfigurationService.shared.stopWatchdog()
             sendFlutterEvent(
                 status: .error,
-                message:
-                    "Failed to add AppKey: \(appKeyStatus.status.debugDescription)",
+                message: "Failed to add AppKey: \(appKeyStatus.status.debugDescription)",
                 eventType: "configuration"
             )
         }
@@ -111,16 +334,11 @@ extension AppDelegate: MeshNetworkDelegate {
 
     // ConfigCompositionDataGet を送信するリトライロジック
     private func sendCompositionDataRequest(to node: Node) {
-        // すでにタイマーが動いていれば何もしない
         guard compositionDataTimer == nil else { return }
-
-        // リトライカウントをリセット
         compositionDataRetries = 0
 
-        // 最初のメッセージを送信
         sendCompositionDataMessage(to: node)
 
-        // タイマーを開始
         compositionDataTimer = Timer.scheduledTimer(
             withTimeInterval: retryTimeInterval,
             repeats: true
@@ -128,8 +346,17 @@ extension AppDelegate: MeshNetworkDelegate {
             guard let self = self else { return }
 
             self.compositionDataRetries += 1
-            print(
-                "Composition Data Get timeout. Retry \(self.compositionDataRetries)/\(self.maxCompositionDataRetries)..."
+            let isConnected = self.connection?.isConnected ?? false
+            let nodeDump = "Node(addr: \(node.primaryUnicastAddress), uuid: \(node.uuid.uuidString))"
+            let detail = "Composition Data Get TIMEOUT. Retry count: \(self.compositionDataRetries)/\(self.maxCompositionDataRetries). NodeDump: \(nodeDump). Connected: \(isConnected)"
+            
+            MeshTrace.log(
+                traceId: ConfigurationService.shared.configTraceId?.uuidString ?? "N/A",
+                step: "COMPOSITION_DATA",
+                event: "TIMEOUT",
+                node: "\(node.primaryUnicastAddress)",
+                state: self.meshState.rawValue,
+                detail: detail
             )
 
             if self.compositionDataRetries <= self.maxCompositionDataRetries {
@@ -137,23 +364,52 @@ extension AppDelegate: MeshNetworkDelegate {
             } else {
                 self.compositionDataTimer?.invalidate()
                 self.compositionDataTimer = nil
-                print(
-                    "Failed to get Composition Data after \(self.maxCompositionDataRetries) retries."
-                )
+                ConfigurationService.shared.stopWatchdog() // タイムアウト諦めたらWatchdogも切る
             }
         }
     }
 
-    // 実際に ConfigCompositionDataGet を送信するヘルパーメソッド
     private func sendCompositionDataMessage(to node: Node) {
+        let isConnected = connection?.isConnected ?? false
+        let transmitterState = meshNetworkManager.transmitter != nil ? "Available" : "Nil"
+        let nodeDump = "Node(addr: \(node.primaryUnicastAddress), uuid: \(node.uuid.uuidString))"
+        let filterType = meshNetworkManager.proxyFilter.type
+        let filterAddresses = meshNetworkManager.proxyFilter.addresses
+        let filterState = "FilterType: \(filterType), Addresses: \(filterAddresses)"
+        
+        let detail = "Sending ConfigCompositionDataGet. NodeDump: \(nodeDump). ProxyFilter: \(filterState). Transmitter: \(transmitterState). Connected: \(isConnected)"
+        
+        MeshTrace.log(
+            traceId: ConfigurationService.shared.configTraceId?.uuidString ?? "N/A",
+            step: "COMPOSITION_DATA",
+            event: "SEND_PRE",
+            node: "\(node.primaryUnicastAddress)",
+            state: meshState.rawValue,
+            detail: detail
+        )
+
         do {
+            ConfigurationService.shared.trackAckSent(messageType: "ConfigCompositionDataGet")
             try meshNetworkManager.send(ConfigCompositionDataGet(), to: node)
-            print(
-                "Sent ConfigCompositionDataGet to \(node.name ?? "Unknown Node")"
+            
+            let detailSuccess = "Sent ConfigCompositionDataGet successfully to \(node.name ?? "Unknown Node")"
+            MeshTrace.log(
+                traceId: ConfigurationService.shared.configTraceId?.uuidString ?? "N/A",
+                step: "COMPOSITION_DATA",
+                event: "SEND_POST_SUCCESS",
+                node: "\(node.primaryUnicastAddress)",
+                state: meshState.rawValue,
+                detail: detailSuccess
             )
         } catch {
-            print(
-                "Failed to send ConfigCompositionDataGet: \(error.localizedDescription)"
+            let detailFail = "Failed to send ConfigCompositionDataGet: \(error.localizedDescription)"
+            MeshTrace.log(
+                traceId: ConfigurationService.shared.configTraceId?.uuidString ?? "N/A",
+                step: "COMPOSITION_DATA",
+                event: "SEND_POST_FAILURE",
+                node: "\(node.primaryUnicastAddress)",
+                state: meshState.rawValue,
+                detail: detailFail
             )
         }
     }
@@ -162,29 +418,81 @@ extension AppDelegate: MeshNetworkDelegate {
         node: Node,
         manager: MeshNetworkManager
     ) {
+        let traceIdStr = ConfigurationService.shared.configTraceId?.uuidString ?? "N/A"
+        guard meshState == .waitComposition else {
+            let detail = "handleCompositionDataStatus: invalid state \(meshState.rawValue)"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "COMPOSITION_DATA",
+                event: "STATE_ERROR",
+                node: "\(node.primaryUnicastAddress)",
+                state: meshState.rawValue,
+                detail: detail
+            )
+            return
+        }
+        
+        guard let appKey = manager.meshNetwork?.applicationKeys.first(where: {
+            node.knows(networkKey: $0.boundNetworkKey)
+        }) else {
+            let detail = "handleCompositionDataStatus: AppKey not found on node"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "COMPOSITION_DATA",
+                event: "APPKEY_ERROR",
+                node: "\(node.primaryUnicastAddress)",
+                state: meshState.rawValue,
+                detail: detail
+            )
+            ConfigurationService.shared.stopWatchdog()
+            return
+        }
+        
+        guard let connection = self.connection, connection.isConnected else {
+            let detail = "handleCompositionDataStatus: GATT proxy not connected"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "COMPOSITION_DATA",
+                event: "PROXY_ERROR",
+                node: "\(node.primaryUnicastAddress)",
+                state: meshState.rawValue,
+                detail: detail
+            )
+            ConfigurationService.shared.stopWatchdog()
+            return
+        }
+        
+        meshState = .configuring
+
         let clientUnicastAddress = Address(0x0001)
         var serverModel: Model?
         var clientModelID: UInt16?
 
-        // elementとmodelを書き出す
         let models = node.elements.flatMap({ $0.models })
 
-        // GenericOnOffServerがいるとき
         if let genericOnOffServerModel = models.first(where: {
             UInt16($0.modelId) == .genericOnOffServerModelId
         }) {
             serverModel = genericOnOffServerModel
             clientModelID = .genericOnOffClientModelId
         }
-        // GenericColorServerがいるとき
         else if let genericColorServerModel = models.first(where: {
             UInt16($0.modelId) == .genericColorServerModelID
         }) {
             serverModel = genericColorServerModel
             clientModelID = .genericColorClientModelID
         }
-        // Configuration可能なサーバーが見つからないとき
         else {
+            let detail = "Valid server model not found"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "COMPOSITION_DATA",
+                event: "MODEL_ERROR",
+                node: "\(node.primaryUnicastAddress)",
+                state: meshState.rawValue,
+                detail: detail
+            )
+            ConfigurationService.shared.stopWatchdog()
             sendFlutterEvent(
                 status: .error,
                 message: "Valid server model not found",
@@ -192,24 +500,14 @@ extension AppDelegate: MeshNetworkDelegate {
             )
             return
         }
-        // AppKeyとGeneric OnOff Serverモデルを見つける
-        guard
-            let appKey = manager.meshNetwork?.applicationKeys.first(where: {
-                node.knows(networkKey: $0.boundNetworkKey)
-            }), let serverModel
-        else {
-            print("AppKey or server model not found")
-            return
-        }
 
         bindModel(
-            model: serverModel,
+            model: serverModel!,
             appKey: appKey,
             manager: manager,
             node: node
         )
 
-        // localElementから対応するモデルを見つける
         guard
             let clientModel = manager.localElements
                 .flatMap({ $0.models })
@@ -217,7 +515,16 @@ extension AppDelegate: MeshNetworkDelegate {
                     $0.modelIdentifier == clientModelID
                 })
         else {
-            print("Failed to find client model.")
+            let detail = "Failed to find client model"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "MODEL_APP_BIND",
+                event: "CLIENT_MODEL_ERROR",
+                node: "\(clientUnicastAddress)",
+                state: meshState.rawValue,
+                detail: detail
+            )
+            ConfigurationService.shared.stopWatchdog()
             return
         }
         do {
@@ -227,17 +534,54 @@ extension AppDelegate: MeshNetworkDelegate {
                     to: clientModel
                 )
             else {
-                print("Failed to create client-model-bind message")
+                let detail = "Failed to create client-model-bind message"
+                MeshTrace.log(
+                    traceId: traceIdStr,
+                    step: "MODEL_APP_BIND",
+                    event: "CLIENT_MESSAGE_ERROR",
+                    node: "\(clientUnicastAddress)",
+                    state: meshState.rawValue,
+                    detail: detail
+                )
+                ConfigurationService.shared.stopWatchdog()
                 return
             }
+            
+            let detailSendPre = "Sending local Client Model Bind (ID: \(clientModel.modelIdentifier)) to ClientUnicastAddress: \(clientUnicastAddress)"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "MODEL_APP_BIND",
+                event: "SEND_PRE_CLIENT",
+                node: "\(clientUnicastAddress)",
+                state: meshState.rawValue,
+                detail: detailSendPre
+            )
+            
+            ConfigurationService.shared.trackAckSent(messageType: "ConfigModelAppBind")
             try manager.send(clientBindMessage, to: clientUnicastAddress)
 
+            let detailSendPost = "Sent local Client Model Bind successfully."
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "MODEL_APP_BIND",
+                event: "SEND_POST_CLIENT_SUCCESS",
+                node: "\(clientUnicastAddress)",
+                state: meshState.rawValue,
+                detail: detailSendPost
+            )
         } catch {
-            print("Failed to bind Client Model")
-            print("\(error.localizedDescription)")
+            let detailSendFail = "Failed to send local Client Model Bind: \(error.localizedDescription)"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "MODEL_APP_BIND",
+                event: "SEND_POST_CLIENT_FAILURE",
+                node: "\(clientUnicastAddress)",
+                state: meshState.rawValue,
+                detail: detailSendFail
+            )
+            ConfigurationService.shared.stopWatchdog()
             return
         }
-        print("Successfully bind client model")
     }
 
     private func bindModel(
@@ -255,12 +599,40 @@ extension AppDelegate: MeshNetworkDelegate {
             print("Message Create Error")
             return
         }
+        
+        let traceIdStr = ConfigurationService.shared.configTraceId?.uuidString ?? "N/A"
+        let detailSendPre = "Sending ConfigModelAppBind to ServerModel (ID: \(model.modelIdentifier)) for address \(node.primaryUnicastAddress)"
+        MeshTrace.log(
+            traceId: traceIdStr,
+            step: "MODEL_APP_BIND",
+            event: "SEND_PRE_SERVER",
+            node: "\(node.primaryUnicastAddress)",
+            state: meshState.rawValue,
+            detail: detailSendPre
+        )
+        
         do {
+            ConfigurationService.shared.trackAckSent(messageType: "ConfigModelAppBind")
             try manager.send(bindMessage, to: node)
-            print("Sent ConfigModelAppBind to \(model.name ?? "Unknown Model")")
+            
+            let detailSendPost = "Sent ConfigModelAppBind successfully."
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "MODEL_APP_BIND",
+                event: "SEND_POST_SERVER_SUCCESS",
+                node: "\(node.primaryUnicastAddress)",
+                state: meshState.rawValue,
+                detail: detailSendPost
+            )
         } catch {
-            print(
-                "Failed to bind AppKey to model: \(error.localizedDescription)"
+            let detailSendFail = "Failed to send ConfigModelAppBind: \(error.localizedDescription)"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "MODEL_APP_BIND",
+                event: "SEND_POST_SERVER_FAILURE",
+                node: "\(node.primaryUnicastAddress)",
+                state: meshState.rawValue,
+                detail: detailSendFail
             )
         }
     }
@@ -270,25 +642,52 @@ extension AppDelegate: MeshNetworkDelegate {
         manager: MeshNetworkManager,
         node: Node
     ) async {
+        let traceIdStr = ConfigurationService.shared.configTraceId?.uuidString ?? "N/A"
         if modelAppStatus.status == .success {
+            let detail = "Successfully bind AppKey to Model. Transitioning to subscription."
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "MODEL_APP_BIND",
+                event: "STATUS_SUCCESS",
+                node: "\(node.primaryUnicastAddress)",
+                state: meshState.rawValue,
+                detail: detail
+            )
+            
             sendFlutterEvent(
                 status: .success,
                 message: "Successfully bind AppKey to Model",
                 eventType: "configuration"
             )
-            guard
-                (manager.meshNetwork?.applicationKeys.first(where: {
-                    node.knows(networkKey: $0.boundNetworkKey)
-                })) != nil
-            else {
-                print("Failed to get app key")
-                return
+            
+            if !ConfigurationService.shared.isSubscribed {
+                meshState = .subscription
+                let result = ConfigurationService.shared.setSubscription(withAddress: node.primaryUnicastAddress)
+                
+                let triggerDetail = "Subscription triggered: \(result.isSuccess) - \(result.message)"
+                MeshTrace.log(
+                    traceId: traceIdStr,
+                    step: "SUBSCRIPTION",
+                    event: "TRIGGER",
+                    node: "\(node.primaryUnicastAddress)",
+                    state: meshState.rawValue,
+                    detail: triggerDetail
+                )
             }
         } else {
+            let detail = "Model bind failed with status: \(modelAppStatus.status)"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "MODEL_APP_BIND",
+                event: "STATUS_FAILURE",
+                node: "\(node.primaryUnicastAddress)",
+                state: meshState.rawValue,
+                detail: detail
+            )
+            ConfigurationService.shared.stopWatchdog()
             sendFlutterEvent(
                 status: .error,
-                message:
-                    "Model bind failed with status: \(modelAppStatus.status)",
+                message: "Model bind failed with status: \(modelAppStatus.status)",
                 eventType: "configuration"
             )
         }

--- a/ios/Runner/Bluetooth/AppDelegate+MeshNetworkDelegate.swift
+++ b/ios/Runner/Bluetooth/AppDelegate+MeshNetworkDelegate.swift
@@ -56,13 +56,15 @@ extension AppDelegate: MeshNetworkDelegate {
             if configSubscriptionState.isSuccess {
                 sendFlutterEvent(
                     status: .success,
-                    message: "Successfully subscribe model"
+                    message: "Successfully subscribe model",
+                    eventType: "subscription"
                 )
             } else {
                 sendFlutterEvent(
                     status: .error,
                     message:
-                        "Failed to subscribe model: \(configSubscriptionState.message)"
+                        "Failed to subscribe model: \(configSubscriptionState.message)",
+                    eventType: "subscription"
                 )
             }
 
@@ -70,13 +72,15 @@ extension AppDelegate: MeshNetworkDelegate {
             if configPublicationStatus.status == .success {
                 sendFlutterEvent(
                     status: .success,
-                    message: "Successfully publish model"
+                    message: "Successfully publish model",
+                    eventType: "publication"
                 )
             } else {
                 sendFlutterEvent(
                     status: .error,
                     message:
-                        "Failed to publish model: \(configPublicationStatus.message)"
+                        "Failed to publish model: \(configPublicationStatus.message)",
+                    eventType: "publication"
                 )
             }
 
@@ -99,7 +103,8 @@ extension AppDelegate: MeshNetworkDelegate {
             sendFlutterEvent(
                 status: .error,
                 message:
-                    "Failed to add AppKey: \(appKeyStatus.status.debugDescription)"
+                    "Failed to add AppKey: \(appKeyStatus.status.debugDescription)",
+                eventType: "configuration"
             )
         }
     }
@@ -182,7 +187,8 @@ extension AppDelegate: MeshNetworkDelegate {
         else {
             sendFlutterEvent(
                 status: .error,
-                message: "Valid server model not found"
+                message: "Valid server model not found",
+                eventType: "configuration"
             )
             return
         }
@@ -267,7 +273,8 @@ extension AppDelegate: MeshNetworkDelegate {
         if modelAppStatus.status == .success {
             sendFlutterEvent(
                 status: .success,
-                message: "Successfully bind AppKey to Model"
+                message: "Successfully bind AppKey to Model",
+                eventType: "configuration"
             )
             guard
                 (manager.meshNetwork?.applicationKeys.first(where: {
@@ -281,7 +288,8 @@ extension AppDelegate: MeshNetworkDelegate {
             sendFlutterEvent(
                 status: .error,
                 message:
-                    "Model bind failed with status: \(modelAppStatus.status)"
+                    "Model bind failed with status: \(modelAppStatus.status)",
+                eventType: "configuration"
             )
         }
     }
@@ -312,7 +320,8 @@ extension AppDelegate: MeshNetworkDelegate {
             print("Failed to find Server model.")
             sendFlutterEvent(
                 status: .error,
-                message: "Failed to find models"
+                message: "Failed to find models",
+                eventType: "colorSet"
             )
             return
         }
@@ -330,21 +339,27 @@ extension AppDelegate: MeshNetworkDelegate {
             print(result)
             sendFlutterEvent(
                 status: .success,
-                message: "Successfully sent message"
+                message: "Successfully sent message",
+                eventType: "colorSet"
             )
         } catch {
             sendFlutterEvent(
                 status: .error,
                 message:
-                    "Failed to send message: \(error.localizedDescription)"
+                    "Failed to send message: \(error.localizedDescription)",
+                eventType: "colorSet"
             )
         }
     }
 
-    private func sendFlutterEvent(status: MeshNetworkStatus, message: String?) {
+    private func sendFlutterEvent(status: MeshNetworkStatus, message: String?, eventType: String? = nil) {
+        var data: [String: Any] = ["message": message ?? "No message"]
+        if let eventType = eventType {
+            data["eventType"] = eventType
+        }
         MeshNetworkEventStreamHandler.shared.sendEvent(
             status: status,
-            data: ["message": message ?? "No message"]
+            data: data
         )
     }
 }

--- a/ios/Runner/Bluetooth/AppDelegate+MeshNetworkDelegate.swift
+++ b/ios/Runner/Bluetooth/AppDelegate+MeshNetworkDelegate.swift
@@ -171,6 +171,7 @@ extension AppDelegate: MeshNetworkDelegate {
             ConfigurationService.shared.expectedDelegate = "ConfigModelPublicationStatus"
             
             if configSubscriptionState.isSuccess {
+                _ = manager.save()
                 let statusDetail = "Successfully subscribe model for \(source)"
                 MeshTrace.log(
                     traceId: traceIdStr,
@@ -228,6 +229,7 @@ extension AppDelegate: MeshNetworkDelegate {
             ConfigurationService.shared.markConfigurationComplete() // 正常終了: isConfiguring リセット + Watchdog停止
             
             if configPublicationStatus.status == .success {
+                _ = manager.save()
                 let statusDetail = "Successfully publish model for \(source)"
                 MeshTrace.log(
                     traceId: traceIdStr,
@@ -302,6 +304,7 @@ extension AppDelegate: MeshNetworkDelegate {
     ) {
         let traceIdStr = ConfigurationService.shared.configTraceId?.uuidString ?? "N/A"
         if appKeyStatus.status == .success {
+            _ = manager.save()
             let detail = "AppKey added successfully. Transitioning to waitComposition."
             MeshTrace.log(
                 traceId: traceIdStr,
@@ -333,7 +336,7 @@ extension AppDelegate: MeshNetworkDelegate {
     }
 
     // ConfigCompositionDataGet を送信するリトライロジック
-    private func sendCompositionDataRequest(to node: Node) {
+    func sendCompositionDataRequest(to node: Node) {
         guard compositionDataTimer == nil else { return }
         compositionDataRetries = 0
 
@@ -644,6 +647,7 @@ extension AppDelegate: MeshNetworkDelegate {
     ) async {
         let traceIdStr = ConfigurationService.shared.configTraceId?.uuidString ?? "N/A"
         if modelAppStatus.status == .success {
+            _ = manager.save()
             let detail = "Successfully bind AppKey to Model. Transitioning to subscription."
             MeshTrace.log(
                 traceId: traceIdStr,
@@ -735,7 +739,6 @@ extension AppDelegate: MeshNetworkDelegate {
                 withTtl: UInt8(5),
                 using: appKey
             )
-            print(result)
             sendFlutterEvent(
                 status: .success,
                 message: "Successfully sent message",

--- a/ios/Runner/Bluetooth/AppDelegate+MeshNetworkDelegate.swift
+++ b/ios/Runner/Bluetooth/AppDelegate+MeshNetworkDelegate.swift
@@ -203,6 +203,10 @@ extension AppDelegate: MeshNetworkDelegate {
                     )
                 }
             } else {
+                ConfigurationService.shared.isSubscribed = false
+                ConfigurationService.shared.isConfiguring = false
+                ConfigurationService.shared.stopWatchdog()
+                
                 let statusDetail = "Failed to subscribe model: \(configSubscriptionState.message) for \(source)"
                 MeshTrace.log(
                     traceId: traceIdStr,
@@ -226,9 +230,9 @@ extension AppDelegate: MeshNetworkDelegate {
             ConfigurationService.shared.lastReceivedEvent = "ConfigModelPublicationStatus Received"
             ConfigurationService.shared.expectedNextEvent = "Flow Complete"
             ConfigurationService.shared.expectedDelegate = "None"
-            ConfigurationService.shared.markConfigurationComplete() // 正常終了: isConfiguring リセット + Watchdog停止
             
             if configPublicationStatus.status == .success {
+                ConfigurationService.shared.markConfigurationComplete() // 正常終了: isConfiguring リセット + Watchdog停止
                 _ = manager.save()
                 let statusDetail = "Successfully publish model for \(source)"
                 MeshTrace.log(
@@ -246,6 +250,10 @@ extension AppDelegate: MeshNetworkDelegate {
                     eventType: "publication"
                 )
             } else {
+                ConfigurationService.shared.isPublished = false
+                ConfigurationService.shared.isConfiguring = false
+                ConfigurationService.shared.stopWatchdog()
+                
                 let statusDetail = "Failed to publish model: \(configPublicationStatus.message) for \(source)"
                 MeshTrace.log(
                     traceId: traceIdStr,
@@ -315,7 +323,13 @@ extension AppDelegate: MeshNetworkDelegate {
                 detail: detail
             )
             meshState = .waitComposition
-            sendCompositionDataRequest(to: node)
+            
+            ConfigurationService.shared.startWatchdog(for: node.primaryUnicastAddress)
+            ConfigurationService.shared.expectedNextEvent = "ConfigCompositionDataStatus"
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                self.sendCompositionDataRequest(to: node)
+            }
         } else {
             let detail = "Failed to add AppKey: \(appKeyStatus.status.debugDescription)"
             MeshTrace.log(
@@ -392,8 +406,9 @@ extension AppDelegate: MeshNetworkDelegate {
         )
 
         do {
+            ConfigurationService.shared.currentMessageHandle?.cancel()
             ConfigurationService.shared.trackAckSent(messageType: "ConfigCompositionDataGet")
-            try meshNetworkManager.send(ConfigCompositionDataGet(), to: node)
+            ConfigurationService.shared.currentMessageHandle = try meshNetworkManager.send(ConfigCompositionDataGet(), to: node)
             
             let detailSuccess = "Sent ConfigCompositionDataGet successfully to \(node.name ?? "Unknown Node")"
             MeshTrace.log(
@@ -561,7 +576,7 @@ extension AppDelegate: MeshNetworkDelegate {
             )
             
             ConfigurationService.shared.trackAckSent(messageType: "ConfigModelAppBind")
-            try manager.send(clientBindMessage, to: clientUnicastAddress)
+            ConfigurationService.shared.currentMessageHandle = try manager.send(clientBindMessage, to: clientUnicastAddress)
 
             let detailSendPost = "Sent local Client Model Bind successfully."
             MeshTrace.log(
@@ -616,7 +631,7 @@ extension AppDelegate: MeshNetworkDelegate {
         
         do {
             ConfigurationService.shared.trackAckSent(messageType: "ConfigModelAppBind")
-            try manager.send(bindMessage, to: node)
+            ConfigurationService.shared.currentMessageHandle = try manager.send(bindMessage, to: node)
             
             let detailSendPost = "Sent ConfigModelAppBind successfully."
             MeshTrace.log(

--- a/ios/Runner/Bluetooth/ConfigurationService.swift
+++ b/ios/Runner/Bluetooth/ConfigurationService.swift
@@ -30,6 +30,21 @@ class ConfigurationService {
     static let shared = ConfigurationService()
     private let manager = MeshNetworkManager.instance
 
+    var isConfiguring = false
+    var isSubscribed = false
+    var isPublished = false
+    var currentTargetAddress: Address?
+
+    // Watchdog, Trace and ACK properties
+    var configTraceId: UUID?
+    var expectedNextEvent: String = "None"
+    var lastReceivedEvent: String = "None"
+    var expectedDelegate: String = "None"
+    var pendingAckMessage: String?
+    var pendingAckSentTime: Date?
+    var proxyFilterUpdatedCount = 0
+    private var watchdogTimer: Timer?
+
     private var periodSteps: UInt8 = 0
     private var periodResolution: StepResolution = .hundredsOfMilliseconds
     private var retransmissionCount: UInt8 = 0
@@ -69,6 +84,34 @@ class ConfigurationService {
     )
         -> ConfigurationServiceResponse
     {
+        guard !isConfiguring else {
+            return ConfigurationServiceResponse(isSuccess: false, message: "Already configuring")
+        }
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
+              appDelegate.meshState == .proxyConnected else {
+            return ConfigurationServiceResponse(isSuccess: false, message: "Invalid state for configureNode")
+        }
+
+        // Trace ID と Watchdog の初期化
+        configTraceId = UUID()
+        let traceIdStr = configTraceId?.uuidString ?? "N/A"
+        expectedNextEvent = "ConfigAppKeyStatus"
+        expectedDelegate = "ConfigAppKeyStatus"
+        lastReceivedEvent = "configureNode Called"
+        
+        MeshTrace.log(
+            traceId: traceIdStr,
+            step: "CONFIGURING",
+            event: "START",
+            node: "\(unicastAddress)",
+            state: "PROXY_CONNECTED",
+            detail: "configureNode started. Initializing trace and watchdog."
+        )
+
+        isConfiguring = true
+        appDelegate.meshState = .configuring
+        startWatchdog(for: unicastAddress)
+
         do {
             let node = try findNode(withUnicastAddress: unicastAddress)
 
@@ -94,31 +137,75 @@ class ConfigurationService {
             }
 
             guard let selectedAppKey = applicationKey else {
+                let detailErr = "No ApplicationKey available"
+                MeshTrace.log(
+                    traceId: traceIdStr,
+                    step: "APP_KEY_ADD",
+                    event: "ERROR",
+                    node: "\(unicastAddress)",
+                    state: "CONFIGURING",
+                    detail: detailErr
+                )
+                stopWatchdog()
+                isConfiguring = false
+                appDelegate.meshState = .proxyConnected // 元に戻す
                 return ConfigurationServiceResponse(
                     isSuccess: false,
-                    message: "No ApplicationKey available"
+                    message: detailErr
                 )
             }
 
             // AppKeyの追加
+            let appKeyCount = manager.meshNetwork?.applicationKeys.count ?? 0
+            let isConnected = appDelegate.connection?.isConnected ?? false
+            let detailBefore = "Sending ConfigAppKeyAdd. AppKey Index: \(selectedAppKey.index). AppKeys count: \(appKeyCount). Connected: \(isConnected). Node UUID: \(node.uuid.uuidString). Node Addr: \(node.primaryUnicastAddress)"
+            
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "APP_KEY_ADD",
+                event: "SEND_PRE",
+                node: "\(unicastAddress)",
+                state: "CONFIGURING",
+                detail: detailBefore
+            )
+            
+            trackAckSent(messageType: "ConfigAppKeyAdd")
             try manager.send(
                 ConfigAppKeyAdd(applicationKey: selectedAppKey),
                 to: node
             )
-            // Nodeの情報をリクエスト
-            try manager.send(ConfigCompositionDataGet(), to: node)
+
+            let detailAfter = "Sent ConfigAppKeyAdd successfully. Awaiting AppKey status response..."
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "APP_KEY_ADD",
+                event: "SEND_POST_SUCCESS",
+                node: "\(unicastAddress)",
+                state: "CONFIGURING",
+                detail: detailAfter
+            )
 
             return ConfigurationServiceResponse(
                 isSuccess: true,
-                message:
-                    "Configuration process started. Awaiting node response..."
+                message: "Configuration process started. Awaiting AppKey status response..."
             )
 
         } catch {
+            let detailErr = "Failed to configure the node: \(error.localizedDescription)"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "APP_KEY_ADD",
+                event: "SEND_POST_FAILURE",
+                node: "\(unicastAddress)",
+                state: "CONFIGURING",
+                detail: detailErr
+            )
+            stopWatchdog()
+            isConfiguring = false
+            appDelegate.meshState = .proxyConnected
             return ConfigurationServiceResponse(
                 isSuccess: false,
-                message:
-                    "Failed to configure the node: \(error.localizedDescription)"
+                message: detailErr
             )
         }
     }
@@ -126,6 +213,25 @@ class ConfigurationService {
     func setSubscription(withAddress address: Address)
         -> ConfigurationServiceResponse
     {
+        guard !isSubscribed else {
+            return ConfigurationServiceResponse(isSuccess: false, message: "Already subscribed")
+        }
+        let traceIdStr = configTraceId?.uuidString ?? "N/A"
+        let appDelegate = UIApplication.shared.delegate as? AppDelegate
+        let stateStr = appDelegate?.meshState.rawValue ?? "UNKNOWN"
+        
+        MeshTrace.log(
+            traceId: traceIdStr,
+            step: "SUBSCRIPTION",
+            event: "START",
+            node: "\(address)",
+            state: stateStr,
+            detail: "setSubscription started"
+        )
+        
+        expectedNextEvent = "ConfigModelSubscriptionStatus"
+        expectedDelegate = "ConfigModelSubscriptionStatus"
+
         var node: Node!
         var serverModel: Model!
         var clientModelID: UInt16?
@@ -135,6 +241,15 @@ class ConfigurationService {
         do {
             node = try findNode(withUnicastAddress: address)
         } catch {
+            let detailErr = "setSubscription failed: Couldn't find node with address \(address)"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "SUBSCRIPTION",
+                event: "NODE_NOT_FOUND_ERROR",
+                node: "\(address)",
+                state: stateStr,
+                detail: detailErr
+            )
             return ConfigurationServiceResponse(
                 isSuccess: false,
                 message: "Couldn't find node"
@@ -154,6 +269,15 @@ class ConfigurationService {
             serverModel = genericColorServerModel
             clientModelID = .genericColorClientModelID
         } else {
+            let detailErr = "setSubscription failed: Couldn't find server model for address \(address)"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "SUBSCRIPTION",
+                event: "SERVER_MODEL_NOT_FOUND",
+                node: "\(address)",
+                state: stateStr,
+                detail: detailErr
+            )
             return ConfigurationServiceResponse(
                 isSuccess: false,
                 message: "Couldn't find server model"
@@ -165,6 +289,15 @@ class ConfigurationService {
                 .flatMap({ $0.models })
                 .first(where: { $0.modelIdentifier == clientModelID }) != nil
         else {
+            let detailErr = "setSubscription failed: Failed to find client model \(clientModelID)"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "SUBSCRIPTION",
+                event: "CLIENT_MODEL_NOT_FOUND",
+                node: "\(address)",
+                state: stateStr,
+                detail: detailErr
+            )
             return ConfigurationServiceResponse(
                 isSuccess: false,
                 message: "Failed to find client model"
@@ -185,6 +318,15 @@ class ConfigurationService {
                 try manager.meshNetwork?.add(group: ledGroup)
                 targetGroup = ledGroup
             } catch {
+                let detailErr = "setSubscription failed: Failed to add group: \(error.localizedDescription)"
+                MeshTrace.log(
+                    traceId: traceIdStr,
+                    step: "SUBSCRIPTION",
+                    event: "GROUP_ADD_ERROR",
+                    node: "\(address)",
+                    state: stateStr,
+                    detail: detailErr
+                )
                 return ConfigurationServiceResponse(
                     isSuccess: false,
                     message:
@@ -193,9 +335,16 @@ class ConfigurationService {
             }
         }
 
-        print("----- Subscription -----")
-        print("target group: \(String(describing: targetGroup?.address))")
         guard let targetGroup else {
+            let detailErr = "setSubscription failed: Failed to find group"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "SUBSCRIPTION",
+                event: "GROUP_NOT_FOUND",
+                node: "\(address)",
+                state: stateStr,
+                detail: detailErr
+            )
             return ConfigurationServiceResponse(
                 isSuccess: false,
                 message: "Failed to find group"
@@ -209,10 +358,41 @@ class ConfigurationService {
                 group: targetGroup,
                 to: serverModel
             )!
+            
+        let isConnected = appDelegate?.connection?.isConnected ?? false
+        let detailSendPre = "Sending ConfigModelSubscriptionAdd to ServerModel (ID: \(serverModel.modelIdentifier)). Group Address: \(targetGroup.address). Connected: \(isConnected)"
+        MeshTrace.log(
+            traceId: traceIdStr,
+            step: "SUBSCRIPTION",
+            event: "SEND_PRE",
+            node: "\(address)",
+            state: stateStr,
+            detail: detailSendPre
+        )
+        
         do {
+            trackAckSent(messageType: "ConfigModelSubscriptionAdd")
             try MeshNetworkManager.instance.send(message, to: node)
-            print("Successfully send subscription message")
+            
+            let detailSendPost = "Sent ConfigModelSubscriptionAdd successfully."
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "SUBSCRIPTION",
+                event: "SEND_POST_SUCCESS",
+                node: "\(address)",
+                state: stateStr,
+                detail: detailSendPost
+            )
         } catch {
+            let detailSendFail = "Failed to send ConfigModelSubscriptionAdd: \(error.localizedDescription)"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "SUBSCRIPTION",
+                event: "SEND_POST_FAILURE",
+                node: "\(address)",
+                state: stateStr,
+                detail: detailSendFail
+            )
             return ConfigurationServiceResponse(
                 isSuccess: false,
                 message: "Failed to add group"
@@ -228,6 +408,27 @@ class ConfigurationService {
     func setPublication(withAddress address: Address)
         -> ConfigurationServiceResponse
     {
+        guard !isPublished else {
+            return ConfigurationServiceResponse(isSuccess: false, message: "Already published")
+        }
+        let traceIdStr = configTraceId?.uuidString ?? "N/A"
+        let appDelegate = UIApplication.shared.delegate as? AppDelegate
+        let stateStr = appDelegate?.meshState.rawValue ?? "UNKNOWN"
+        
+        MeshTrace.log(
+            traceId: traceIdStr,
+            step: "PUBLICATION",
+            event: "START",
+            node: "\(address)",
+            state: stateStr,
+            detail: "setPublication started"
+        )
+        
+        expectedNextEvent = "ConfigModelPublicationStatus"
+        expectedDelegate = "ConfigModelPublicationStatus"
+
+        isPublished = true
+
         var node: Node!
         var serverModel: Model!
         var clientModelID: UInt16?
@@ -236,6 +437,16 @@ class ConfigurationService {
         do {
             node = try findNode(withUnicastAddress: address)
         } catch {
+            let detailErr = "setPublication failed: Couldn't find node with address \(address)"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "PUBLICATION",
+                event: "NODE_NOT_FOUND_ERROR",
+                node: "\(address)",
+                state: stateStr,
+                detail: detailErr
+            )
+            isPublished = false
             return ConfigurationServiceResponse(
                 isSuccess: false,
                 message: "Couldn't find node"
@@ -255,6 +466,16 @@ class ConfigurationService {
             serverModel = genericColorServerModel
             clientModelID = .genericColorClientModelID
         } else {
+            let detailErr = "setPublication failed: Couldn't find server model for address \(address)"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "PUBLICATION",
+                event: "SERVER_MODEL_NOT_FOUND",
+                node: "\(address)",
+                state: stateStr,
+                detail: detailErr
+            )
+            isPublished = false
             return ConfigurationServiceResponse(
                 isSuccess: false,
                 message: "Couldn't find server model"
@@ -265,6 +486,16 @@ class ConfigurationService {
             let clientModel = manager.localElements.flatMap({ $0.models })
                 .first(where: { $0.modelIdentifier == clientModelID })
         else {
+            let detailErr = "setPublication failed: Failed to find client model \(clientModelID)"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "PUBLICATION",
+                event: "CLIENT_MODEL_NOT_FOUND",
+                node: "\(address)",
+                state: stateStr,
+                detail: detailErr
+            )
+            isPublished = false
             return ConfigurationServiceResponse(
                 isSuccess: false,
                 message: "Failed to find client model"
@@ -277,15 +508,33 @@ class ConfigurationService {
             let targetGroup = network.groups
                 .first(where: { $0.address == MeshAddress(.allLedNodes) })
         else {
+            let detailErr = "setPublication failed: Group not found for publication"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "PUBLICATION",
+                event: "GROUP_NOT_FOUND",
+                node: "\(address)",
+                state: stateStr,
+                detail: detailErr
+            )
+            isPublished = false
             return ConfigurationServiceResponse(
                 isSuccess: false,
                 message: "Group not found"
             )
         }
-        print("----- Publication -----")
-        print("target group: \(targetGroup.address)")
 
         guard let applicationKey = clientModel.boundApplicationKeys.first else {
+            let detailErr = "setPublication failed: Bound ApplicationKey not found for client model \(clientModelID)"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "PUBLICATION",
+                event: "APP_KEY_NOT_BOUND",
+                node: "\(address)",
+                state: stateStr,
+                detail: detailErr
+            )
+            isPublished = false
             return ConfigurationServiceResponse(
                 isSuccess: false,
                 message: "ApplicationKey not found"
@@ -312,14 +561,46 @@ class ConfigurationService {
                 publish,
                 to: serverModel
             )!
+            
+        let isConnected = appDelegate?.connection?.isConnected ?? false
+        let detailSendPre = "Sending ConfigModelPublicationSet to ServerModel. Group Address: \(targetGroup.address). ApplicationKey: \(applicationKey.index). Connected: \(isConnected)"
+        MeshTrace.log(
+            traceId: traceIdStr,
+            step: "PUBLICATION",
+            event: "SEND_PRE",
+            node: "\(address)",
+            state: stateStr,
+            detail: detailSendPre
+        )
+        
         do {
+            trackAckSent(messageType: "ConfigModelPublicationSet")
             try MeshNetworkManager.instance.send(
                 publicationMessage,
                 to: node,
                 withTtl: UInt8(3)
             )
-            print("Successfully send publication message!")
+            
+            let detailSendPost = "Sent ConfigModelPublicationSet successfully."
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "PUBLICATION",
+                event: "SEND_POST_SUCCESS",
+                node: "\(address)",
+                state: stateStr,
+                detail: detailSendPost
+            )
         } catch {
+            let detailSendFail = "Failed to send ConfigModelPublicationSet: \(error.localizedDescription)"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "PUBLICATION",
+                event: "SEND_POST_FAILURE",
+                node: "\(address)",
+                state: stateStr,
+                detail: detailSendFail
+            )
+            isPublished = false
             return ConfigurationServiceResponse(
                 isSuccess: false,
                 message: "Failed to send message"
@@ -335,10 +616,144 @@ class ConfigurationService {
     private func findNode(withUnicastAddress unicastAddress: Address) throws
         -> Node
     {
+        logNodeResolution(forAddress: unicastAddress, step: "NODE_RESOLUTION", event: "FIND_NODE_CALL")
         guard let node = manager.meshNetwork?.node(withAddress: unicastAddress)
         else {
+            let traceIdStr = configTraceId?.uuidString ?? "N/A"
+            let stateStr = (UIApplication.shared.delegate as? AppDelegate)?.meshState.rawValue ?? "UNKNOWN"
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "NODE_RESOLUTION",
+                event: "FIND_NODE_FAILED",
+                node: "\(unicastAddress)",
+                state: stateStr,
+                detail: "Could not find node in meshNetwork.nodes!"
+            )
             throw ConfigurationServiceError.nodeNotFound
         }
         return node
+    }
+}
+
+// MARK: - ACK, Watchdog and Resolution Helpers
+
+extension ConfigurationService {
+    
+    /// 新しいプロビジョニング/コンフィグレーションセッション開始前に全ステートをリセット
+    func resetForNewSession() {
+        isConfiguring = false
+        isSubscribed = false
+        isPublished = false
+        currentTargetAddress = nil
+        configTraceId = nil
+        expectedNextEvent = "None"
+        lastReceivedEvent = "None"
+        expectedDelegate = "None"
+        pendingAckMessage = nil
+        pendingAckSentTime = nil
+        proxyFilterUpdatedCount = 0
+        stopWatchdog()
+    }
+    
+    func trackAckSent(messageType: String) {
+        self.pendingAckMessage = messageType
+        self.pendingAckSentTime = Date()
+    }
+
+    func logNodeResolution(forAddress address: Address, uuidString: String? = nil, step: String, event: String) {
+        let traceIdStr = configTraceId?.uuidString ?? "N/A"
+        let stateStr = (UIApplication.shared.delegate as? AppDelegate)?.meshState.rawValue ?? "UNKNOWN"
+        let network = manager.meshNetwork
+        let allNodes = network?.nodes ?? []
+        let nodesSummary = allNodes.map { "Node(addr: \($0.primaryUnicastAddress), uuid: \($0.uuid.uuidString), name: \($0.name ?? "N/A"))" }.joined(separator: ", ")
+        
+        var uuidMatchStr = "None"
+        if let uuidStr = uuidString, let uuid = UUID(uuidString: uuidStr) {
+            if let match = allNodes.first(where: { $0.uuid == uuid }) {
+                uuidMatchStr = "Node(addr: \(match.primaryUnicastAddress), uuid: \(match.uuid.uuidString))"
+            }
+        }
+        
+        var addressMatchStr = "None"
+        if let match = network?.node(withAddress: address) {
+            addressMatchStr = "Node(addr: \(match.primaryUnicastAddress), uuid: \(match.uuid.uuidString))"
+        }
+        
+        let detail = "Nodes count: \(allNodes.count). Nodes: [\(nodesSummary)]. UUID Match for \(uuidString ?? "nil"): \(uuidMatchStr). Address Match for \(address): \(addressMatchStr)"
+        
+        MeshTrace.log(
+            traceId: traceIdStr,
+            step: step,
+            event: event,
+            node: "\(address)",
+            state: stateStr,
+            detail: detail
+        )
+    }
+
+    func startWatchdog(for nodeAddress: Address) {
+        watchdogTimer?.invalidate()
+        watchdogTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
+            guard let self = self else { return }
+            let traceIdStr = self.configTraceId?.uuidString ?? "N/A"
+            let node = self.manager.meshNetwork?.node(withAddress: nodeAddress)
+            
+            var nodeDump = "Node not found for address \(nodeAddress)"
+            if let node = node {
+                let boundKeys = node.elements.flatMap { $0.models }.flatMap { $0.boundApplicationKeys }.map { "\($0.index)" }.joined(separator: ",")
+                nodeDump = "Node(addr: \(nodeAddress), uuid: \(node.uuid.uuidString), boundAppKeys: [\(boundKeys)])"
+            }
+            
+            let proxyConnected = (UIApplication.shared.delegate as? AppDelegate)?.connection?.isConnected ?? false
+            let hasTransmitter = self.manager.transmitter != nil
+            
+            // proxyFilterの状態
+            let filterType = self.manager.proxyFilter.type
+            let filterAddresses = self.manager.proxyFilter.addresses
+            let filterState = "FilterType: \(filterType), Addresses: \(filterAddresses)"
+            
+            let detail = "Watchdog tick. Expected: \(self.expectedNextEvent), ExpectedDelegate: \(self.expectedDelegate), LastReceived: \(self.lastReceivedEvent), PendingAck: \(self.pendingAckMessage ?? "None"), Dump: \(nodeDump), ProxyConnected: \(proxyConnected), HasTransmitter: \(hasTransmitter), ProxyFilter: \(filterState)"
+            
+            MeshTrace.log(
+                traceId: traceIdStr,
+                step: "WATCHDOG",
+                event: "TICK",
+                node: "\(nodeAddress)",
+                state: (UIApplication.shared.delegate as? AppDelegate)?.meshState.rawValue ?? "UNKNOWN",
+                detail: detail
+            )
+        }
+    }
+
+    func stopWatchdog() {
+        watchdogTimer?.invalidate()
+        watchdogTimer = nil
+    }
+    
+    /// コンフィグレーション完了時に呼ぶ（isConfiguringリセット含む）
+    func markConfigurationComplete() {
+        isConfiguring = false
+        currentTargetAddress = nil
+        stopWatchdog()
+    }
+}
+
+import os.log
+
+class MeshTrace {
+    static let logSubsystem = "com.soccerapp.mesh"
+    static let logCategory = "Trace"
+    static let osLog = OSLog(subsystem: logSubsystem, category: logCategory)
+
+    static func log(
+        traceId: String,
+        step: String,
+        event: String,
+        node: String,
+        state: String,
+        detail: String
+    ) {
+        let message = "[\(traceId)] [\(step)] [\(event)] [\(node)] [\(state)] [\(detail)]"
+        print(message)
     }
 }

--- a/ios/Runner/Bluetooth/ConfigurationService.swift
+++ b/ios/Runner/Bluetooth/ConfigurationService.swift
@@ -36,6 +36,7 @@ class ConfigurationService {
     var currentTargetAddress: Address?
 
     // Watchdog, Trace and ACK properties
+    var currentMessageHandle: MessageHandle?
     var configTraceId: UUID?
     var expectedNextEvent: String = "None"
     var lastReceivedEvent: String = "None"
@@ -119,18 +120,8 @@ class ConfigurationService {
 
 
             // AppKeyの取得，無ければ生成
-            var applicationKey: ApplicationKey?
-            if let availableKeys = manager.meshNetwork?.applicationKeys
-                .notKnownTo(node: node), !availableKeys.isEmpty
-            {
-                let keys = availableKeys.filter {
-                    node.knows(networkKey: $0.boundNetworkKey)
-                }
-                if !keys.isEmpty {
-                    applicationKey = keys[0]
-                }
-            }
-
+            var applicationKey: ApplicationKey? = manager.meshNetwork?.applicationKeys.first
+            
             if applicationKey == nil {
                 // applicationKeyを新しく生成
                 applicationKey = try manager.meshNetwork?.add(
@@ -158,6 +149,19 @@ class ConfigurationService {
                 )
             }
 
+            if !node.applicationKeys.isEmpty {
+                MeshTrace.log(traceId: traceIdStr, step: "APP_KEY_ADD", event: "SKIP", node: "\(unicastAddress)", state: "CONFIGURING", detail: "Node already has application keys. Skipping ConfigAppKeyAdd.")
+                appDelegate.meshState = .waitComposition
+                
+                startWatchdog(for: node.primaryUnicastAddress)
+                expectedNextEvent = "ConfigCompositionDataStatus"
+                
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                    appDelegate.sendCompositionDataRequest(to: node)
+                }
+                return ConfigurationServiceResponse(isSuccess: true, message: "Skipped AppKeyAdd. Requesting Composition Data...")
+            }
+
             // AppKeyの追加
             let appKeyCount = manager.meshNetwork?.applicationKeys.count ?? 0
             let isConnected = appDelegate.connection?.isConnected ?? false
@@ -173,7 +177,7 @@ class ConfigurationService {
             )
             
             trackAckSent(messageType: "ConfigAppKeyAdd")
-            try manager.send(
+            currentMessageHandle = try manager.send(
                 ConfigAppKeyAdd(applicationKey: selectedAppKey),
                 to: node
             )
@@ -354,6 +358,12 @@ class ConfigurationService {
             )
         }
 
+        // 購読済みスキップ判定
+        if serverModel.subscriptions.contains(targetGroup) {
+            MeshTrace.log(traceId: traceIdStr, step: "SUBSCRIPTION", event: "SKIP", node: "\(address)", state: stateStr, detail: "Model already subscribed to group \(targetGroup.address). Skipping.")
+            appDelegate?.meshState = .publication
+            return setPublication(withAddress: address)
+        }
 
         /// Subscription メッセージ
         let message: AcknowledgedConfigMessage =
@@ -376,7 +386,7 @@ class ConfigurationService {
         
         do {
             trackAckSent(messageType: "ConfigModelSubscriptionAdd")
-            try MeshNetworkManager.instance.send(message, to: node)
+            currentMessageHandle = try MeshNetworkManager.instance.send(message, to: node)
             
             let detailSendPost = "Sent ConfigModelSubscriptionAdd successfully."
             MeshTrace.log(
@@ -545,6 +555,14 @@ class ConfigurationService {
             )
         }
 
+        // Publish設定済みスキップ判定
+        if serverModel.publish?.publicationAddress == targetGroup.address {
+            MeshTrace.log(traceId: traceIdStr, step: "PUBLICATION", event: "SKIP", node: "\(address)", state: stateStr, detail: "Model already published to group \(targetGroup.address). Skipping.")
+            markConfigurationComplete()
+            _ = MeshNetworkManager.instance.save()
+            MeshNetworkEventStreamHandler.shared.sendEvent(status: .success, data: ["message": "Configuration complete (Skipped Publication)", "eventType": "publication"])
+            return ConfigurationServiceResponse(isSuccess: true, message: "Already published to group. Configuration complete.")
+        }
 
         let publish = Publish(
             to: targetGroup.address,
@@ -580,7 +598,7 @@ class ConfigurationService {
         
         do {
             trackAckSent(messageType: "ConfigModelPublicationSet")
-            try MeshNetworkManager.instance.send(
+            currentMessageHandle = try MeshNetworkManager.instance.send(
                 publicationMessage,
                 to: node,
                 withTtl: UInt8(3)
@@ -734,6 +752,8 @@ extension ConfigurationService {
             if self.watchdogTicks >= self.maxWatchdogTicks {
                 MeshTrace.log(traceId: traceIdStr, step: "WATCHDOG", event: "TIMEOUT", node: "\(nodeAddress)", state: (UIApplication.shared.delegate as? AppDelegate)?.meshState.rawValue ?? "UNKNOWN", detail: "No response for 15s. Aborting sequence.")
                 
+                self.currentMessageHandle?.cancel()
+                self.currentMessageHandle = nil
                 self.stopWatchdog()
                 self.isConfiguring = false
                 self.isSubscribed = false
@@ -751,6 +771,8 @@ extension ConfigurationService {
     func stopWatchdog() {
         watchdogTimer?.invalidate()
         watchdogTimer = nil
+        currentMessageHandle?.cancel()
+        currentMessageHandle = nil
     }
     
     /// コンフィグレーション完了時に呼ぶ（isConfiguringリセット含む）

--- a/ios/Runner/Bluetooth/ConfigurationService.swift
+++ b/ios/Runner/Bluetooth/ConfigurationService.swift
@@ -221,7 +221,7 @@ class ConfigurationService {
         -> ConfigurationServiceResponse
     {
         guard !isSubscribed else {
-            return ConfigurationServiceResponse(isSuccess: false, message: "Already subscribed")
+            return ConfigurationServiceResponse(isSuccess: true, message: "Already subscribed")
         }
         let traceIdStr = configTraceId?.uuidString ?? "N/A"
         let appDelegate = UIApplication.shared.delegate as? AppDelegate
@@ -423,7 +423,7 @@ class ConfigurationService {
         -> ConfigurationServiceResponse
     {
         guard !isPublished else {
-            return ConfigurationServiceResponse(isSuccess: false, message: "Already published")
+            return ConfigurationServiceResponse(isSuccess: true, message: "Already published")
         }
         let traceIdStr = configTraceId?.uuidString ?? "N/A"
         let appDelegate = UIApplication.shared.delegate as? AppDelegate
@@ -778,7 +778,16 @@ extension ConfigurationService {
     /// コンフィグレーション完了時に呼ぶ（isConfiguringリセット含む）
     func markConfigurationComplete() {
         isConfiguring = false
+        isSubscribed = false
+        isPublished = false
         currentTargetAddress = nil
+        configTraceId = nil
+        expectedNextEvent = "None"
+        lastReceivedEvent = "None"
+        expectedDelegate = "None"
+        pendingAckMessage = nil
+        pendingAckSentTime = nil
+        proxyFilterUpdatedCount = 0
         stopWatchdog()
     }
 }

--- a/ios/Runner/Bluetooth/ConfigurationService.swift
+++ b/ios/Runner/Bluetooth/ConfigurationService.swift
@@ -44,6 +44,8 @@ class ConfigurationService {
     var pendingAckSentTime: Date?
     var proxyFilterUpdatedCount = 0
     private var watchdogTimer: Timer?
+    private var watchdogTicks = 0
+    private let maxWatchdogTicks = 3
 
     private var periodSteps: UInt8 = 0
     private var periodResolution: StepResolution = .hundredsOfMilliseconds
@@ -114,6 +116,7 @@ class ConfigurationService {
 
         do {
             let node = try findNode(withUnicastAddress: unicastAddress)
+
 
             // AppKeyの取得，無ければ生成
             var applicationKey: ApplicationKey?
@@ -351,6 +354,7 @@ class ConfigurationService {
             )
         }
 
+
         /// Subscription メッセージ
         let message: AcknowledgedConfigMessage =
             ConfigModelSubscriptionAdd(group: targetGroup, to: serverModel)
@@ -541,6 +545,7 @@ class ConfigurationService {
             )
         }
 
+
         let publish = Publish(
             to: targetGroup.address,
             using: applicationKey,
@@ -693,8 +698,10 @@ extension ConfigurationService {
 
     func startWatchdog(for nodeAddress: Address) {
         watchdogTimer?.invalidate()
+        watchdogTicks = 0
         watchdogTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
             guard let self = self else { return }
+            self.watchdogTicks += 1
             let traceIdStr = self.configTraceId?.uuidString ?? "N/A"
             let node = self.manager.meshNetwork?.node(withAddress: nodeAddress)
             
@@ -722,6 +729,22 @@ extension ConfigurationService {
                 state: (UIApplication.shared.delegate as? AppDelegate)?.meshState.rawValue ?? "UNKNOWN",
                 detail: detail
             )
+            
+            // 15秒応答なしでのアクティブリカバリ
+            if self.watchdogTicks >= self.maxWatchdogTicks {
+                MeshTrace.log(traceId: traceIdStr, step: "WATCHDOG", event: "TIMEOUT", node: "\(nodeAddress)", state: (UIApplication.shared.delegate as? AppDelegate)?.meshState.rawValue ?? "UNKNOWN", detail: "No response for 15s. Aborting sequence.")
+                
+                self.stopWatchdog()
+                self.isConfiguring = false
+                self.isSubscribed = false
+                self.isPublished = false
+                
+                var eventType = "configuration"
+                if self.expectedNextEvent == "ConfigModelSubscriptionStatus" { eventType = "subscription" }
+                else if self.expectedNextEvent == "ConfigModelPublicationStatus" { eventType = "publication" }
+                
+                MeshNetworkEventStreamHandler.shared.sendEvent(status: .error, data: ["message": "タイムアウト: デバイスからの応答がありません", "eventType": eventType])
+            }
         }
     }
 

--- a/ios/Runner/Bluetooth/ProvisioningService.swift
+++ b/ios/Runner/Bluetooth/ProvisioningService.swift
@@ -74,16 +74,18 @@ class ProvisioningService: NSObject {
                     appDelegate.meshState = .waitProxyConnection
                 }
             }
-            
-            _provisioningEventStreamHandler.sendEvent(
-                status: .complete,
-                data: [
-                    "message": "Node already provisioned. Resuming configuration...",
-                    "nodeUuid": existingNode.uuid.uuidString,
-                    "unicastAddress": existingNode.primaryUnicastAddress as Any
-                ]
-            )
             result(["isSuccess": true, "message": "Resuming configuration."])
+            
+            DispatchQueue.main.async {
+                self._provisioningEventStreamHandler.sendEvent(
+                    status: .complete,
+                    data: [
+                        "message": "Node already provisioned. Resuming configuration...",
+                        "nodeUuid": existingNode.uuid.uuidString,
+                        "unicastAddress": existingNode.primaryUnicastAddress as Any
+                    ]
+                )
+            }
             return
             }
         }

--- a/ios/Runner/Bluetooth/ProvisioningService.swift
+++ b/ios/Runner/Bluetooth/ProvisioningService.swift
@@ -48,7 +48,23 @@ class ProvisioningService: NSObject {
         for uuid: String,
         result: @escaping FlutterResult
     ) {
+        // 既存のProxy接続（NetworkConnection）を明示的に切断し、状態をリセットする
+        if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+            appDelegate.connection?.close()
+        }
+        
         cleanupProvisioning(closeBearer: true)
+
+        // 同一UUIDの既存ノードがあれば、データベースから削除する
+        if let meshNetwork = meshNetworkManager?.meshNetwork,
+           let existingNode = meshNetwork.nodes.first(where: { $0.uuid.uuidString == uuid }) {
+            print("[ProvisioningService] Found duplicate node with UUID: \(uuid). Removing from database before provisioning.")
+            meshNetwork.remove(node: existingNode)
+            _ = meshNetworkManager?.save()
+        }
+
+        ConfigurationService.shared.resetForNewSession()
+        (UIApplication.shared.delegate as? AppDelegate)?.meshState = .provisioning
 
         guard let deviceInfo = bleScanner?.discoveredDevicesList[uuid],
             let peripheral = deviceInfo["peripheral"] as? CBPeripheral,
@@ -252,6 +268,14 @@ extension ProvisioningService: GattBearerDelegate {
                     cleanupProvisioning()
                     return
                 }
+
+                ConfigurationService.shared.currentTargetAddress = node.primaryUnicastAddress
+                if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+                    appDelegate.meshState = .provisioningComplete
+                    appDelegate.connection?.open()
+                    appDelegate.meshState = .waitProxyConnection
+                }
+
                 _provisioningEventStreamHandler.sendEvent(
                     status: .complete,
                     data: [

--- a/ios/Runner/Bluetooth/ProvisioningService.swift
+++ b/ios/Runner/Bluetooth/ProvisioningService.swift
@@ -55,12 +55,37 @@ class ProvisioningService: NSObject {
         
         cleanupProvisioning(closeBearer: true)
 
-        // 同一UUIDの既存ノードがあれば、データベースから削除する
-        if let meshNetwork = meshNetworkManager?.meshNetwork,
-           let existingNode = meshNetwork.nodes.first(where: { $0.uuid.uuidString == uuid }) {
-            print("[ProvisioningService] Found duplicate node with UUID: \(uuid). Removing from database before provisioning.")
-            meshNetwork.remove(node: existingNode)
-            _ = meshNetworkManager?.save()
+        // 同一UUIDの既存ノードがあれば、ProvisioningをスキップしてGATT Proxy接続へ進む（自動レジューム）
+        if let meshNetwork = meshNetworkManager?.meshNetwork {
+            let uuidUpper = uuid.uppercased()
+            let allUuids = meshNetwork.nodes.map { $0.uuid.uuidString }.joined(separator: ", ")
+            print("[ProvisioningService] Requested UUID: \(uuidUpper)")
+            print("[ProvisioningService] DB Node UUIDs: [\(allUuids)]")
+            
+            if let existingNode = meshNetwork.nodes.first(where: { $0.uuid.uuidString.uppercased() == uuidUpper }) {
+            print("[ProvisioningService] Found existing node with UUID: \(uuid). Skipping provisioning and auto-resuming configuration.")
+            
+            ConfigurationService.shared.currentTargetAddress = existingNode.primaryUnicastAddress
+            if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+                appDelegate.meshState = .provisioningComplete
+                appDelegate.connection?.close()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    appDelegate.connection?.open()
+                    appDelegate.meshState = .waitProxyConnection
+                }
+            }
+            
+            _provisioningEventStreamHandler.sendEvent(
+                status: .complete,
+                data: [
+                    "message": "Node already provisioned. Resuming configuration...",
+                    "nodeUuid": existingNode.uuid.uuidString,
+                    "unicastAddress": existingNode.primaryUnicastAddress as Any
+                ]
+            )
+            result(["isSuccess": true, "message": "Resuming configuration."])
+            return
+            }
         }
 
         ConfigurationService.shared.resetForNewSession()
@@ -335,6 +360,8 @@ extension ProvisioningService: ProvisioningDelegate {
                 self.startProvisioning()
 
             case .complete:
+                let saveSuccess = self.meshNetworkManager?.save() ?? false
+                print("[ProvisioningService] meshNetworkManager.save() at .complete result: \(saveSuccess)")
                 do {
                     try self.bearer?.close()
                 } catch {

--- a/ios/Runner/MeshNetwork/NetworkConnection.swift
+++ b/ios/Runner/MeshNetwork/NetworkConnection.swift
@@ -121,6 +121,7 @@ class NetworkConnection: NSObject, Bearer {
     }
 
     func open() {
+        isExplicitlyClosing = false
         if !isStarted && isConnectionModeAutomatic
             && centralManager.state == .poweredOn
         {
@@ -133,11 +134,18 @@ class NetworkConnection: NSObject, Bearer {
         isStarted = true
     }
 
+    var isExplicitlyClosing = false
+
     func close() {
+        print("[NetworkConnection] Explicitly closing all proxies and stopping scan.")
+        isExplicitlyClosing = true
         centralManager.stopScan()
         proxies.forEach { $0.close() }
         proxies.removeAll()
         isStarted = false
+        isOpen = false
+        // 即座にデリゲートに通知し、SDKの内部状態 (proxyFilterなど) をリセットする
+        delegate?.bearer(self, didClose: nil)
     }
 
     func disconnect() {
@@ -145,17 +153,62 @@ class NetworkConnection: NSObject, Bearer {
     }
 
     func send(_ data: Data, ofType type: PduType) throws {
-        // Send the message to all open GATT Proxy nodes.
-        var success = false
-        var e: Error = BearerError.bearerClosed
-        proxies.filter { $0.isOpen }.forEach {
-            do {
-                try $0.send(data, ofType: type)
-                success = true
-            } catch {
-                e = error
+        let traceIdStr = ConfigurationService.shared.configTraceId?.uuidString ?? "N/A"
+        
+        var stateStr = "UNKNOWN"
+        if Thread.isMainThread {
+            stateStr = (UIApplication.shared.delegate as? AppDelegate)?.meshState.rawValue ?? "UNKNOWN"
+        } else {
+            stateStr = DispatchQueue.main.sync {
+                return (UIApplication.shared.delegate as? AppDelegate)?.meshState.rawValue ?? "UNKNOWN"
             }
         }
+        let openProxies = proxies.filter { $0.isOpen }
+        let openProxiesCount = openProxies.count
+        let totalProxiesCount = proxies.count
+        let dataHex = data.map { String(format: "%02x", $0) }.joined()
+        
+        let detailPre = "NetworkConnection.send: data hex: \(dataHex), PduType: \(type). Total proxies: \(totalProxiesCount), Open proxies: \(openProxiesCount)"
+        MeshTrace.log(
+            traceId: traceIdStr,
+            step: "TRANSPORT",
+            event: "SEND_DATA_PRE",
+            node: "N/A",
+            state: stateStr,
+            detail: detailPre
+        )
+
+        var success = false
+        var e: Error = BearerError.bearerClosed
+        
+        for proxy in openProxies {
+            do {
+                try proxy.send(data, ofType: type)
+                success = true
+                
+                let detailSuccess = "NetworkConnection.send: Successfully sent to proxy \(proxy.identifier.uuidString) (\(proxy.name ?? "N/A"))"
+                MeshTrace.log(
+                    traceId: traceIdStr,
+                    step: "TRANSPORT",
+                    event: "SEND_DATA_SUCCESS",
+                    node: "N/A",
+                    state: stateStr,
+                    detail: detailSuccess
+                )
+            } catch {
+                e = error
+                let detailFail = "NetworkConnection.send: Failed to send to proxy \(proxy.identifier.uuidString) (\(proxy.name ?? "N/A")): \(error.localizedDescription)"
+                MeshTrace.log(
+                    traceId: traceIdStr,
+                    step: "TRANSPORT",
+                    event: "SEND_DATA_FAILURE",
+                    node: "N/A",
+                    state: stateStr,
+                    detail: detailFail
+                )
+            }
+        }
+        
         if !success {
             throw e
         }
@@ -235,20 +288,30 @@ extension NetworkConnection: CBCentralManagerDelegate {
             print("Device: \(deviceName), RSSI: \(RSSI)")
         }
 
+        let targetAddress = ConfigurationService.shared.currentTargetAddress
+
         // Is it a Network ID or Private Network Identity beacon?
         if let networkIdentity = advertisementData.networkIdentity {
             guard meshNetwork.matches(networkIdentity: networkIdentity) else {
                 // A Node from another mesh network.
                 return
             }
-        } else {
+        } else if let nodeIdentity = advertisementData.nodeIdentity {
             // Is it a Node Identity or Private Node Identity beacon?
-            guard let nodeIdentity = advertisementData.nodeIdentity,
-                meshNetwork.matches(nodeIdentity: nodeIdentity)
-            else {
+            guard let node = meshNetwork.node(matchingNodeIdentity: nodeIdentity) else {
                 // A Node from another mesh network.
                 return
             }
+            if let target = targetAddress {
+                guard node.primaryUnicastAddress == target else {
+                    print("Skipping Node Identity proxy because address \(node.primaryUnicastAddress) != target \(target)")
+                    return
+                }
+            } else {
+                guard meshNetwork.matches(nodeIdentity: nodeIdentity) else { return }
+            }
+        } else {
+            return
         }
         // Add a new bearer.
         use(proxy: GattBearer(target: peripheral))
@@ -258,8 +321,9 @@ extension NetworkConnection: CBCentralManagerDelegate {
 extension NetworkConnection: GattBearerDelegate, BearerDataDelegate {
 
     func bearerDidOpen(_ bearer: Bearer) {
-        guard !isOpen else { return }
         isOpen = true
+        // 毎回デリゲートに通知する。ProxyFilter初期化（proxyConfiguration送信）は
+        // bearerDidOpen経由でトリガーされるため、ガードでスキップしてはいけない。
         delegate?.bearerDidOpen(self)
     }
 
@@ -275,9 +339,13 @@ extension NetworkConnection: GattBearerDelegate, BearerDataDelegate {
                 options: nil
             )
         }
+        
+        isOpen = !proxies.isEmpty
         if proxies.isEmpty {
-            isOpen = false
-            delegate?.bearer(self, didClose: nil)
+            if !isExplicitlyClosing {
+                delegate?.bearer(self, didClose: nil)
+            }
+            isExplicitlyClosing = false
         }
     }
 

--- a/ios/Runner/MeshNetwork/NetworkConnection.swift
+++ b/ios/Runner/MeshNetwork/NetworkConnection.swift
@@ -154,15 +154,7 @@ class NetworkConnection: NSObject, Bearer {
 
     func send(_ data: Data, ofType type: PduType) throws {
         let traceIdStr = ConfigurationService.shared.configTraceId?.uuidString ?? "N/A"
-        
-        var stateStr = "UNKNOWN"
-        if Thread.isMainThread {
-            stateStr = (UIApplication.shared.delegate as? AppDelegate)?.meshState.rawValue ?? "UNKNOWN"
-        } else {
-            stateStr = DispatchQueue.main.sync {
-                return (UIApplication.shared.delegate as? AppDelegate)?.meshState.rawValue ?? "UNKNOWN"
-            }
-        }
+        let stateStr = "UNKNOWN"
         let openProxies = proxies.filter { $0.isOpen }
         let openProxiesCount = openProxies.count
         let totalProxiesCount = proxies.count

--- a/ios/test_proxy_filter.swift
+++ b/ios/test_proxy_filter.swift
@@ -1,0 +1,5 @@
+import Foundation
+import NordicMesh
+
+let filter = ProxyFilter(delegate: nil)
+filter.add(address: 0x0005)

--- a/ios/test_proxy_filter.swift
+++ b/ios/test_proxy_filter.swift
@@ -1,5 +1,0 @@
-import Foundation
-import NordicMesh
-
-let filter = ProxyFilter(delegate: nil)
-filter.add(address: 0x0005)

--- a/lib/pages/connection_page/provisioning_progress_dialog.dart
+++ b/lib/pages/connection_page/provisioning_progress_dialog.dart
@@ -77,12 +77,12 @@ class _ProvisioningProgressDialogState
   StreamSubscription<Map<String, dynamic>>? _subscription; // provisioningStream
   StreamSubscription<Map<String, dynamic>>?
   _meshSubscription; // meshNetworkStream
-  Timer? _timeoutTimer;
 
   bool _isDebugMode = false;
   WizardStep _currentWizardStep = WizardStep.provisioning;
   StepStatus _currentStepStatus = StepStatus.running;
   int? _unicastAddress;
+  late String _targetUuid;
 
   // Provisioningサブステップ用
   ProvisioningStep _currentStep = ProvisioningStep.connecting;
@@ -92,6 +92,7 @@ class _ProvisioningProgressDialogState
   void initState() {
     super.initState();
     _isDebugMode = widget.isMockDevice;
+    _targetUuid = widget.deviceUuid;
 
     // イベントストリームはダイアログの初期化時に一度だけ購読し，disposeまで維持する
     _meshSubscription = MeshNetwork.meshNetworkStream.listen(
@@ -107,7 +108,6 @@ class _ProvisioningProgressDialogState
   void dispose() {
     _subscription?.cancel();
     _meshSubscription?.cancel();
-    _timeoutTimer?.cancel();
     super.dispose();
   }
 
@@ -216,7 +216,6 @@ class _ProvisioningProgressDialogState
 
   /// 各ステップ成功時の状態更新
   void _handleStepSuccess(String successMessage) {
-    _timeoutTimer?.cancel();
     setState(() {
       _currentStepStatus = StepStatus.success;
       _statusMessage = successMessage;
@@ -226,28 +225,12 @@ class _ProvisioningProgressDialogState
 
   /// 各ステップ失敗（エラー）時の状態更新
   void _handleStepFailure(String errorMessage) {
-    _timeoutTimer?.cancel();
     setState(() {
       _currentStepStatus = StepStatus.failed;
       _statusMessage = errorMessage;
     });
     debugPrint('[Wizard] Step $_currentWizardStep failed: $errorMessage');
   }
-
-  // /// タイムアウトタイマーの起動（15秒）
-  // void _startTimeoutTimer() {
-  //   _timeoutTimer?.cancel();
-  //   if (_isDebugMode) return; // デバッグモードではタイムアウトさせない
-
-  //   _timeoutTimer = Timer(const Duration(seconds: 15), () {
-  //     if (!mounted) return;
-  //     debugPrint('[Wizard] Step $_currentWizardStep timed out.');
-  //     setState(() {
-  //       _currentStepStatus = StepStatus.failed;
-  //       _statusMessage = 'タイムアウトしました。もう一度お試しください。';
-  //     });
-  //   });
-  // }
 
   /// 各ステップのアクションを起動するメソッド
   Future<void> _triggerStepAction() async {
@@ -297,7 +280,7 @@ class _ProvisioningProgressDialogState
       // 以前のプロビジョニング購読があれば解除
       await _subscription?.cancel();
 
-      final response = await _provisioning.startProvisioning(widget.deviceUuid);
+      final response = await _provisioning.startProvisioning(_targetUuid);
 
       if (!response['isSuccess']) {
         if (!mounted) return;
@@ -319,8 +302,17 @@ class _ProvisioningProgressDialogState
 
             if (step == ProvisioningStep.complete) {
               _unicastAddress = data['unicastAddress'] as int?;
+              final nodeUuid = data['nodeUuid'] as String?;
+              if (nodeUuid != null && nodeUuid.isNotEmpty) {
+                _targetUuid = nodeUuid;
+                debugPrint('[Wizard] Target UUID updated to true Mesh UUID: $_targetUuid');
+              }
               _currentStepStatus = StepStatus.success;
-              _statusMessage = 'プロビジョニングが完了しました！';
+              if (message.contains('Resuming')) {
+                _statusMessage = '既存デバイスを検知しました。設定を再開します...';
+              } else {
+                _statusMessage = 'プロビジョニングが完了しました！';
+              }
               debugPrint(
                 '[Wizard] Provisioning complete. UnicastAddress: $_unicastAddress',
               );
@@ -371,41 +363,6 @@ class _ProvisioningProgressDialogState
     }
   }
 
-  // /// NEXTボタンまたは完了ボタンが押下されたときの処理
-  // void _handleNextStep() {
-  //   if (_currentWizardStep == WizardStep.publication &&
-  //       _currentStepStatus == StepStatus.success) {
-  //     // 最終ステップ完了時はダイアログを閉じる
-  //     Navigator.of(context).pop();
-  //     return;
-  //   }
-
-  //   final nextIndex = _currentWizardStep.stepIndex + 1;
-  //   if (nextIndex < WizardStep.values.length) {
-  //     setState(() {
-  //       _currentWizardStep = WizardStep.values[nextIndex];
-  //       _currentStepStatus = StepStatus.waitingUserConfirmation;
-
-  //       // 次のステップの初期表示メッセージを設定
-  //       switch (_currentWizardStep) {
-  //         case WizardStep.configuration:
-  //           _statusMessage = 'Configurationを開始しますか？';
-  //           break;
-  //         case WizardStep.subscription:
-  //           _statusMessage = 'Set Subscriptionを開始しますか？';
-  //           break;
-  //         case WizardStep.publication:
-  //           _statusMessage = 'Set Publicationを開始しますか？';
-  //           break;
-  //         default:
-  //           break;
-  //       }
-  //     });
-  //     debugPrint(
-  //       '[Wizard] Transitioned to $_currentWizardStep (waitingUserConfirmation)',
-  //     );
-  //   }
-  // }
 
   /// ウィザード全体の進捗率の計算 (0.0 ~ 1.0)
   double get _progressValue {

--- a/lib/pages/connection_page/provisioning_progress_dialog.dart
+++ b/lib/pages/connection_page/provisioning_progress_dialog.dart
@@ -114,15 +114,70 @@ class _ProvisioningProgressDialogState
   /// メッシュネットワークからのイベント通知を処理するハンドラ
   void _handleMeshNetworkEvent(Map<String, dynamic> event) {
     if (!mounted) return;
-    if (_currentStepStatus != StepStatus.running) return;
 
     final eventType = event['eventType'] as String?;
     final status = event['status'] as String?;
     final message = event['message'] as String? ?? '';
+    final meshState = event['meshState'] as String?;
 
     debugPrint(
-      '[Wizard Stream] Received eventType: $eventType, status: $status, message: $message',
+      '[Wizard Stream] Received eventType: $eventType, status: $status, message: $message, meshState: $meshState',
     );
+
+    if (eventType == 'meshStateChanged' && meshState != null) {
+      setState(() {
+        switch (meshState) {
+          case 'PROVISIONING':
+            _currentWizardStep = WizardStep.provisioning;
+            _currentStepStatus = StepStatus.running;
+            _statusMessage = 'プロビジョニング中...';
+            break;
+          case 'PROVISIONING_COMPLETE':
+            _currentWizardStep = WizardStep.provisioning;
+            _currentStepStatus = StepStatus.success;
+            _statusMessage = 'プロビジョニング完了';
+            break;
+          case 'WAIT_PROXY_CONNECTION':
+            _currentWizardStep = WizardStep.configuration;
+            _currentStepStatus = StepStatus.running;
+            _statusMessage = 'Proxy接続を待っています...';
+            break;
+          case 'PROXY_CONNECTED':
+            _currentWizardStep = WizardStep.configuration;
+            _currentStepStatus = StepStatus.running;
+            _statusMessage = '接続完了';
+            break;
+          case 'WAIT_COMPOSITION':
+            _currentWizardStep = WizardStep.configuration;
+            _currentStepStatus = StepStatus.running;
+            _statusMessage = 'Composition Dataを取得中...';
+            break;
+          case 'CONFIGURING':
+            _currentWizardStep = WizardStep.configuration;
+            _currentStepStatus = StepStatus.running;
+            _statusMessage = '設定中...';
+            break;
+          case 'COMPLETE':
+            _currentWizardStep = WizardStep.configuration;
+            _currentStepStatus = StepStatus.success;
+            _statusMessage = 'Configuration完了';
+            break;
+          case 'SUBSCRIPTION':
+            _currentWizardStep = WizardStep.subscription;
+            _currentStepStatus = StepStatus.running;
+            _statusMessage = 'Subscription設定中...';
+            break;
+          case 'PUBLICATION':
+            _currentWizardStep = WizardStep.publication;
+            _currentStepStatus = StepStatus.running;
+            _statusMessage = 'Publication設定中...';
+            break;
+        }
+      });
+      return;
+    }
+
+    if (_currentStepStatus != StepStatus.running) return;
 
     if (_currentWizardStep == WizardStep.configuration) {
       if (eventType == 'configuration') {
@@ -179,20 +234,20 @@ class _ProvisioningProgressDialogState
     debugPrint('[Wizard] Step $_currentWizardStep failed: $errorMessage');
   }
 
-  /// タイムアウトタイマーの起動（15秒）
-  void _startTimeoutTimer() {
-    _timeoutTimer?.cancel();
-    if (_isDebugMode) return; // デバッグモードではタイムアウトさせない
+  // /// タイムアウトタイマーの起動（15秒）
+  // void _startTimeoutTimer() {
+  //   _timeoutTimer?.cancel();
+  //   if (_isDebugMode) return; // デバッグモードではタイムアウトさせない
 
-    _timeoutTimer = Timer(const Duration(seconds: 15), () {
-      if (!mounted) return;
-      debugPrint('[Wizard] Step $_currentWizardStep timed out.');
-      setState(() {
-        _currentStepStatus = StepStatus.failed;
-        _statusMessage = 'タイムアウトしました。もう一度お試しください。';
-      });
-    });
-  }
+  //   _timeoutTimer = Timer(const Duration(seconds: 15), () {
+  //     if (!mounted) return;
+  //     debugPrint('[Wizard] Step $_currentWizardStep timed out.');
+  //     setState(() {
+  //       _currentStepStatus = StepStatus.failed;
+  //       _statusMessage = 'タイムアウトしました。もう一度お試しください。';
+  //     });
+  //   });
+  // }
 
   /// 各ステップのアクションを起動するメソッド
   Future<void> _triggerStepAction() async {
@@ -229,64 +284,10 @@ class _ProvisioningProgressDialogState
       return;
     }
 
-    // 本番環境フロー
-    if (_unicastAddress == null &&
-        _currentWizardStep != WizardStep.provisioning) {
-      _handleStepFailure('ユニキャストアドレスが見つかりません。');
-      return;
-    }
-
-    switch (_currentWizardStep) {
-      case WizardStep.provisioning:
-        _statusMessage = '接続中...';
-        _startProvisioning();
-        break;
-
-      case WizardStep.configuration:
-        _statusMessage = 'Configuration実行中...';
-        _startTimeoutTimer();
-        try {
-          final response = await Provisioning.configureNode(_unicastAddress!);
-          debugPrint('[Wizard Config] Method call response: $response');
-          if (response['isSuccess'] != true) {
-            _handleStepFailure('Configuration開始失敗: ${response['message']}');
-          }
-        } catch (e) {
-          _handleStepFailure('Configuration実行例外: $e');
-        }
-        break;
-
-      case WizardStep.subscription:
-        _statusMessage = 'Subscription設定実行中...';
-        _startTimeoutTimer();
-        try {
-          final response = await Provisioning.setSubscription(
-            unicastAddress: _unicastAddress!,
-          );
-          debugPrint('[Wizard Sub] Method call response: $response');
-          if (response['isSuccess'] != true) {
-            _handleStepFailure('Subscription設定開始失敗: ${response['message']}');
-          }
-        } catch (e) {
-          _handleStepFailure('Subscription設定実行例外: $e');
-        }
-        break;
-
-      case WizardStep.publication:
-        _statusMessage = 'Publication設定実行中...';
-        _startTimeoutTimer();
-        try {
-          final response = await Provisioning.setPublication(
-            unicastAddress: _unicastAddress!,
-          );
-          debugPrint('[Wizard Pub] Method call response: $response');
-          if (response['isSuccess'] != true) {
-            _handleStepFailure('Publication設定開始失敗: ${response['message']}');
-          }
-        } catch (e) {
-          _handleStepFailure('Publication設定実行例外: $e');
-        }
-        break;
+    // 本番環境フローでは最初のProvisioningのみFlutter側からトリガーする
+    if (_currentWizardStep == WizardStep.provisioning) {
+      _statusMessage = '接続中...';
+      _startProvisioning();
     }
   }
 
@@ -370,41 +371,41 @@ class _ProvisioningProgressDialogState
     }
   }
 
-  /// NEXTボタンまたは完了ボタンが押下されたときの処理
-  void _handleNextStep() {
-    if (_currentWizardStep == WizardStep.publication &&
-        _currentStepStatus == StepStatus.success) {
-      // 最終ステップ完了時はダイアログを閉じる
-      Navigator.of(context).pop();
-      return;
-    }
+  // /// NEXTボタンまたは完了ボタンが押下されたときの処理
+  // void _handleNextStep() {
+  //   if (_currentWizardStep == WizardStep.publication &&
+  //       _currentStepStatus == StepStatus.success) {
+  //     // 最終ステップ完了時はダイアログを閉じる
+  //     Navigator.of(context).pop();
+  //     return;
+  //   }
 
-    final nextIndex = _currentWizardStep.stepIndex + 1;
-    if (nextIndex < WizardStep.values.length) {
-      setState(() {
-        _currentWizardStep = WizardStep.values[nextIndex];
-        _currentStepStatus = StepStatus.waitingUserConfirmation;
+  //   final nextIndex = _currentWizardStep.stepIndex + 1;
+  //   if (nextIndex < WizardStep.values.length) {
+  //     setState(() {
+  //       _currentWizardStep = WizardStep.values[nextIndex];
+  //       _currentStepStatus = StepStatus.waitingUserConfirmation;
 
-        // 次のステップの初期表示メッセージを設定
-        switch (_currentWizardStep) {
-          case WizardStep.configuration:
-            _statusMessage = 'Configurationを開始しますか？';
-            break;
-          case WizardStep.subscription:
-            _statusMessage = 'Set Subscriptionを開始しますか？';
-            break;
-          case WizardStep.publication:
-            _statusMessage = 'Set Publicationを開始しますか？';
-            break;
-          default:
-            break;
-        }
-      });
-      debugPrint(
-        '[Wizard] Transitioned to $_currentWizardStep (waitingUserConfirmation)',
-      );
-    }
-  }
+  //       // 次のステップの初期表示メッセージを設定
+  //       switch (_currentWizardStep) {
+  //         case WizardStep.configuration:
+  //           _statusMessage = 'Configurationを開始しますか？';
+  //           break;
+  //         case WizardStep.subscription:
+  //           _statusMessage = 'Set Subscriptionを開始しますか？';
+  //           break;
+  //         case WizardStep.publication:
+  //           _statusMessage = 'Set Publicationを開始しますか？';
+  //           break;
+  //         default:
+  //           break;
+  //       }
+  //     });
+  //     debugPrint(
+  //       '[Wizard] Transitioned to $_currentWizardStep (waitingUserConfirmation)',
+  //     );
+  //   }
+  // }
 
   /// ウィザード全体の進捗率の計算 (0.0 ~ 1.0)
   double get _progressValue {
@@ -660,40 +661,26 @@ class _ProvisioningProgressDialogState
 
   /// アクションボタン表示
   Widget _buildActionButton() {
-    if (_currentStepStatus == StepStatus.running) {
-      return const SizedBox.shrink(); // 実行中はボタンを表示しない
-    }
+    final isFinished =
+        _currentWizardStep == WizardStep.publication &&
+        _currentStepStatus == StepStatus.success;
+    final isFailed = _currentStepStatus == StepStatus.failed;
 
-    if (_currentStepStatus == StepStatus.waitingUserConfirmation) {
+    if (isFinished) {
       return SizedBox(
         width: double.infinity,
         child: ElevatedButton(
-          onPressed: _triggerStepAction,
+          onPressed: () => Navigator.of(context).pop(),
           style: ElevatedButton.styleFrom(
             backgroundColor: Colors.blue,
             foregroundColor: Colors.white,
           ),
-          child: const Text('YES'),
+          child: const Text('完了'),
         ),
       );
     }
 
-    if (_currentStepStatus == StepStatus.success) {
-      final isLastStep = _currentWizardStep == WizardStep.publication;
-      return SizedBox(
-        width: double.infinity,
-        child: ElevatedButton(
-          onPressed: _handleNextStep,
-          style: ElevatedButton.styleFrom(
-            backgroundColor: Colors.blue,
-            foregroundColor: Colors.white,
-          ),
-          child: Text(isLastStep ? '完了' : 'NEXT'),
-        ),
-      );
-    }
-
-    if (_currentStepStatus == StepStatus.failed) {
+    if (isFailed) {
       return Row(
         children: [
           Expanded(
@@ -705,7 +692,14 @@ class _ProvisioningProgressDialogState
           const SizedBox(width: 12),
           Expanded(
             child: ElevatedButton(
-              onPressed: _triggerStepAction,
+              onPressed: () {
+                setState(() {
+                  _currentWizardStep = WizardStep.provisioning;
+                  _currentStep = ProvisioningStep.connecting;
+                  _statusMessage = 'プロビジョニングを開始しています...';
+                });
+                _triggerStepAction();
+              },
               style: ElevatedButton.styleFrom(
                 backgroundColor: Colors.red,
                 foregroundColor: Colors.white,

--- a/lib/pages/connection_page/provisioning_progress_dialog.dart
+++ b/lib/pages/connection_page/provisioning_progress_dialog.dart
@@ -305,7 +305,9 @@ class _ProvisioningProgressDialogState
               final nodeUuid = data['nodeUuid'] as String?;
               if (nodeUuid != null && nodeUuid.isNotEmpty) {
                 _targetUuid = nodeUuid;
-                debugPrint('[Wizard] Target UUID updated to true Mesh UUID: $_targetUuid');
+                debugPrint(
+                  '[Wizard] Target UUID updated to true Mesh UUID: $_targetUuid',
+                );
               }
               _currentStepStatus = StepStatus.success;
               if (message.contains('Resuming')) {
@@ -362,7 +364,6 @@ class _ProvisioningProgressDialogState
       });
     }
   }
-
 
   /// ウィザード全体の進捗率の計算 (0.0 ~ 1.0)
   double get _progressValue {

--- a/lib/pages/connection_page/provisioning_progress_dialog.dart
+++ b/lib/pages/connection_page/provisioning_progress_dialog.dart
@@ -2,8 +2,27 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:soccer_app_flutter/features/platform_channels/provisioning.dart';
+import 'package:soccer_app_flutter/features/platform_channels/mesh_network.dart';
 
-/// プロビジョニングの進捗状態を表す列挙型
+/// プロビジョニングおよびセットアップウィザードの各ステップを表す列挙型
+enum WizardStep {
+  provisioning(0, 'Provisioning', Icons.bluetooth_searching, Colors.blue),
+  configuration(1, 'Configuration', Icons.settings, Colors.blue),
+  subscription(2, 'Subscription', Icons.notifications_active, Colors.blue),
+  publication(3, 'Publication', Icons.publish, Colors.blue);
+
+  const WizardStep(this.stepIndex, this.displayName, this.icon, this.color);
+
+  final int stepIndex;
+  final String displayName;
+  final IconData icon;
+  final Color color;
+}
+
+/// ウィザード内の各ステップの状態を表す列挙型
+enum StepStatus { idle, waitingUserConfirmation, running, success, failed }
+
+/// プロビジョニングの進捗状態を表す列挙型（内部サブステップ用）
 enum ProvisioningStep {
   connecting(0, '接続中', Icons.bluetooth, Colors.blue),
   discovering(1, 'サービス検索中', Icons.bluetooth_searching, Colors.blue),
@@ -31,21 +50,10 @@ enum ProvisioningStep {
   );
 }
 
-/// プロビジョニング進捗ダイアログ
+/// プロビジョニング進捗ダイアログ (セットアップウィザード)
 ///
-/// BLEデバイスのプロビジョニング進捗をステップ表示付きプログレスバーで表示します．
-///
-/// ### 使用例:
-/// ```dart
-/// showDialog(
-///   context: context,
-///   barrierDismissible: false,
-///   builder: (context) => ProvisioningProgressDialog(
-///     deviceName: 'My Device',
-///     deviceUuid: 'xxxx-xxxx-xxxx',
-///   ),
-/// );
-/// ```
+/// BLEデバイスのプロビジョニングから各種設定（Configuration, Subscription, Publication）までを
+/// 順番に実行するウィザード形式のフローを表示します．
 class ProvisioningProgressDialog extends StatefulWidget {
   final String deviceName;
   final String deviceUuid;
@@ -66,37 +74,273 @@ class ProvisioningProgressDialog extends StatefulWidget {
 class _ProvisioningProgressDialogState
     extends State<ProvisioningProgressDialog> {
   final Provisioning _provisioning = Provisioning();
-  StreamSubscription<Map<String, dynamic>>? _subscription;
+  StreamSubscription<Map<String, dynamic>>? _subscription; // provisioningStream
+  StreamSubscription<Map<String, dynamic>>?
+  _meshSubscription; // meshNetworkStream
+  Timer? _timeoutTimer;
+
+  bool _isDebugMode = false;
+  WizardStep _currentWizardStep = WizardStep.provisioning;
+  StepStatus _currentStepStatus = StepStatus.running;
+  int? _unicastAddress;
+
+  // Provisioningサブステップ用
   ProvisioningStep _currentStep = ProvisioningStep.connecting;
-  ProvisioningStep _lastStepBeforeError = ProvisioningStep.connecting;
   String _statusMessage = 'プロビジョニングを開始しています...';
-
-  bool get _isCompleted => _currentStep == ProvisioningStep.complete;
-  bool get _hasError => _currentStep == ProvisioningStep.error;
-
-  // 全ステップ（エラーを除く）
-  static final List<ProvisioningStep> _allSteps =
-      ProvisioningStep.values
-          .where((e) => e != ProvisioningStep.error)
-          .toList();
 
   @override
   void initState() {
     super.initState();
-    if (widget.isMockDevice) {
-      _startProvisioningDebug();
-    } else {
-      _startProvisioning();
-    }
+    _isDebugMode = widget.isMockDevice;
+
+    // イベントストリームはダイアログの初期化時に一度だけ購読し，disposeまで維持する
+    _meshSubscription = MeshNetwork.meshNetworkStream.listen(
+      _handleMeshNetworkEvent,
+      onError: _handleMeshNetworkError,
+    );
+
+    // 最初のステップ (Provisioning) は自動的に実行を開始する
+    _triggerStepAction();
   }
 
   @override
   void dispose() {
     _subscription?.cancel();
+    _meshSubscription?.cancel();
+    _timeoutTimer?.cancel();
     super.dispose();
   }
 
-  /// デバッグ用: 各ステップを2秒間隔で擬似的に進行させる
+  /// メッシュネットワークからのイベント通知を処理するハンドラ
+  void _handleMeshNetworkEvent(Map<String, dynamic> event) {
+    if (!mounted) return;
+    if (_currentStepStatus != StepStatus.running) return;
+
+    final eventType = event['eventType'] as String?;
+    final status = event['status'] as String?;
+    final message = event['message'] as String? ?? '';
+
+    debugPrint(
+      '[Wizard Stream] Received eventType: $eventType, status: $status, message: $message',
+    );
+
+    if (_currentWizardStep == WizardStep.configuration) {
+      if (eventType == 'configuration') {
+        if (status == 'success') {
+          _handleStepSuccess('Configuration完了');
+        } else if (status == 'error') {
+          _handleStepFailure('Configuration失敗: $message');
+        }
+      }
+    } else if (_currentWizardStep == WizardStep.subscription) {
+      if (eventType == 'subscription') {
+        if (status == 'success') {
+          _handleStepSuccess('Subscription設定完了');
+        } else if (status == 'error') {
+          _handleStepFailure('Subscription設定失敗: $message');
+        }
+      }
+    } else if (_currentWizardStep == WizardStep.publication) {
+      if (eventType == 'publication') {
+        if (status == 'success') {
+          _handleStepSuccess('Publication設定完了');
+        } else if (status == 'error') {
+          _handleStepFailure('Publication設定失敗: $message');
+        }
+      }
+    }
+  }
+
+  /// メッシュネットワークエラーハンドラ
+  void _handleMeshNetworkError(dynamic error) {
+    if (!mounted) return;
+    if (_currentStepStatus == StepStatus.running) {
+      _handleStepFailure('通信エラーが発生しました: $error');
+    }
+  }
+
+  /// 各ステップ成功時の状態更新
+  void _handleStepSuccess(String successMessage) {
+    _timeoutTimer?.cancel();
+    setState(() {
+      _currentStepStatus = StepStatus.success;
+      _statusMessage = successMessage;
+    });
+    debugPrint('[Wizard] Step $_currentWizardStep succeeded.');
+  }
+
+  /// 各ステップ失敗（エラー）時の状態更新
+  void _handleStepFailure(String errorMessage) {
+    _timeoutTimer?.cancel();
+    setState(() {
+      _currentStepStatus = StepStatus.failed;
+      _statusMessage = errorMessage;
+    });
+    debugPrint('[Wizard] Step $_currentWizardStep failed: $errorMessage');
+  }
+
+  /// タイムアウトタイマーの起動（15秒）
+  void _startTimeoutTimer() {
+    _timeoutTimer?.cancel();
+    if (_isDebugMode) return; // デバッグモードではタイムアウトさせない
+
+    _timeoutTimer = Timer(const Duration(seconds: 15), () {
+      if (!mounted) return;
+      debugPrint('[Wizard] Step $_currentWizardStep timed out.');
+      setState(() {
+        _currentStepStatus = StepStatus.failed;
+        _statusMessage = 'タイムアウトしました。もう一度お試しください。';
+      });
+    });
+  }
+
+  /// 各ステップのアクションを起動するメソッド
+  Future<void> _triggerStepAction() async {
+    setState(() {
+      _currentStepStatus = StepStatus.running;
+    });
+
+    debugPrint(
+      '[Wizard] Running step: $_currentWizardStep (DebugMode: $_isDebugMode)',
+    );
+
+    // デバッグモード（疑似実行）
+    if (_isDebugMode) {
+      switch (_currentWizardStep) {
+        case WizardStep.provisioning:
+          _startProvisioningDebug();
+          break;
+        case WizardStep.configuration:
+          _statusMessage = 'Configuration実行中... (Debug)';
+          await Future.delayed(const Duration(seconds: 2));
+          if (mounted) _handleStepSuccess('Configuration完了 (Debug)');
+          break;
+        case WizardStep.subscription:
+          _statusMessage = 'Subscription設定実行中... (Debug)';
+          await Future.delayed(const Duration(seconds: 2));
+          if (mounted) _handleStepSuccess('Subscription設定完了 (Debug)');
+          break;
+        case WizardStep.publication:
+          _statusMessage = 'Publication設定実行中... (Debug)';
+          await Future.delayed(const Duration(seconds: 2));
+          if (mounted) _handleStepSuccess('Publication設定完了 (Debug)');
+          break;
+      }
+      return;
+    }
+
+    // 本番環境フロー
+    if (_unicastAddress == null &&
+        _currentWizardStep != WizardStep.provisioning) {
+      _handleStepFailure('ユニキャストアドレスが見つかりません。');
+      return;
+    }
+
+    switch (_currentWizardStep) {
+      case WizardStep.provisioning:
+        _statusMessage = '接続中...';
+        _startProvisioning();
+        break;
+
+      case WizardStep.configuration:
+        _statusMessage = 'Configuration実行中...';
+        _startTimeoutTimer();
+        try {
+          final response = await Provisioning.configureNode(_unicastAddress!);
+          debugPrint('[Wizard Config] Method call response: $response');
+          if (response['isSuccess'] != true) {
+            _handleStepFailure('Configuration開始失敗: ${response['message']}');
+          }
+        } catch (e) {
+          _handleStepFailure('Configuration実行例外: $e');
+        }
+        break;
+
+      case WizardStep.subscription:
+        _statusMessage = 'Subscription設定実行中...';
+        _startTimeoutTimer();
+        try {
+          final response = await Provisioning.setSubscription(
+            unicastAddress: _unicastAddress!,
+          );
+          debugPrint('[Wizard Sub] Method call response: $response');
+          if (response['isSuccess'] != true) {
+            _handleStepFailure('Subscription設定開始失敗: ${response['message']}');
+          }
+        } catch (e) {
+          _handleStepFailure('Subscription設定実行例外: $e');
+        }
+        break;
+
+      case WizardStep.publication:
+        _statusMessage = 'Publication設定実行中...';
+        _startTimeoutTimer();
+        try {
+          final response = await Provisioning.setPublication(
+            unicastAddress: _unicastAddress!,
+          );
+          debugPrint('[Wizard Pub] Method call response: $response');
+          if (response['isSuccess'] != true) {
+            _handleStepFailure('Publication設定開始失敗: ${response['message']}');
+          }
+        } catch (e) {
+          _handleStepFailure('Publication設定実行例外: $e');
+        }
+        break;
+    }
+  }
+
+  /// 本番用のプロビジョニング実行メソッド
+  Future<void> _startProvisioning() async {
+    try {
+      // 以前のプロビジョニング購読があれば解除
+      await _subscription?.cancel();
+
+      final response = await _provisioning.startProvisioning(widget.deviceUuid);
+
+      if (!response['isSuccess']) {
+        if (!mounted) return;
+        _handleStepFailure('プロビジョニング開始失敗: ${response['message']}');
+        return;
+      }
+
+      _subscription = _provisioning.provisioningStream.listen(
+        (data) {
+          if (!mounted) return;
+
+          final status = data['status'] as String? ?? 'unknown';
+          final message = data['message'] as String? ?? '';
+
+          final step = ProvisioningStep.fromStatus(status);
+          setState(() {
+            _currentStep = step;
+            _statusMessage = message;
+
+            if (step == ProvisioningStep.complete) {
+              _unicastAddress = data['unicastAddress'] as int?;
+              _currentStepStatus = StepStatus.success;
+              _statusMessage = 'プロビジョニングが完了しました！';
+              debugPrint(
+                '[Wizard] Provisioning complete. UnicastAddress: $_unicastAddress',
+              );
+            } else if (step == ProvisioningStep.error) {
+              _currentStepStatus = StepStatus.failed;
+              _statusMessage = 'プロビジョニング失敗: $message';
+              debugPrint('[Wizard] Provisioning failed: $message');
+            }
+          });
+        },
+        onError: (error) {
+          if (!mounted) return;
+          _handleStepFailure('プロビジョニングエラー: $error');
+        },
+      );
+    } catch (e) {
+      _handleStepFailure('プロビジョニング中に例外が発生しました: $e');
+    }
+  }
+
+  /// デバッグ用のプロビジョニング擬似実行メソッド
   Future<void> _startProvisioningDebug() async {
     const steps = [
       ('connecting', '接続中...'),
@@ -107,82 +351,100 @@ class _ProvisioningProgressDialogState
     ];
 
     for (final (status, message) in steps) {
-      await Future.delayed(const Duration(seconds: 2));
+      await Future.delayed(const Duration(seconds: 1));
       if (!mounted) return;
       final step = ProvisioningStep.fromStatus(status);
       setState(() {
-        if (step != ProvisioningStep.error) {
-          _lastStepBeforeError = step;
-        }
         _currentStep = step;
         _statusMessage = message;
+
+        if (step == ProvisioningStep.complete) {
+          _unicastAddress = 99; // デバッグ用の疑似ユニキャストアドレス
+          _currentStepStatus = StepStatus.success;
+          _statusMessage = 'プロビジョニングが完了しました！ (Debug)';
+          debugPrint(
+            '[Wizard Debug] Provisioning complete. Mock Unicast Address: 99',
+          );
+        }
       });
     }
   }
 
-  Future<void> _startProvisioning() async {
-    try {
-      // プロビジョニング開始
-      final response = await _provisioning.startProvisioning(widget.deviceUuid);
+  /// NEXTボタンまたは完了ボタンが押下されたときの処理
+  void _handleNextStep() {
+    if (_currentWizardStep == WizardStep.publication &&
+        _currentStepStatus == StepStatus.success) {
+      // 最終ステップ完了時はダイアログを閉じる
+      Navigator.of(context).pop();
+      return;
+    }
 
-      if (!response['isSuccess']) {
-        if (!mounted) return;
-        setState(() {
-          _currentStep = ProvisioningStep.error;
-          _statusMessage = 'エラー: ${response['message']}';
-        });
-        return;
-      }
-
-      // プロビジョニングストリームを購読
-      _subscription = _provisioning.provisioningStream.listen(
-        (data) {
-          if (!mounted) return;
-
-          final status = data['status'] as String? ?? 'unknown';
-          final message = data['message'] as String? ?? '';
-
-          final step = ProvisioningStep.fromStatus(status);
-          setState(() {
-            if (step != ProvisioningStep.error) {
-              _lastStepBeforeError = step;
-            }
-            _currentStep = step;
-            _statusMessage = message;
-          });
-        },
-        onError: (error) {
-          if (!mounted) return;
-          setState(() {
-            _currentStep = ProvisioningStep.error;
-            _statusMessage = 'エラーが発生しました: $error';
-          });
-        },
-      );
-    } catch (e) {
-      if (!mounted) return;
+    final nextIndex = _currentWizardStep.stepIndex + 1;
+    if (nextIndex < WizardStep.values.length) {
       setState(() {
-        _currentStep = ProvisioningStep.error;
-        _statusMessage = '予期しないエラー: $e';
+        _currentWizardStep = WizardStep.values[nextIndex];
+        _currentStepStatus = StepStatus.waitingUserConfirmation;
+
+        // 次のステップの初期表示メッセージを設定
+        switch (_currentWizardStep) {
+          case WizardStep.configuration:
+            _statusMessage = 'Configurationを開始しますか？';
+            break;
+          case WizardStep.subscription:
+            _statusMessage = 'Set Subscriptionを開始しますか？';
+            break;
+          case WizardStep.publication:
+            _statusMessage = 'Set Publicationを開始しますか？';
+            break;
+          default:
+            break;
+        }
       });
+      debugPrint(
+        '[Wizard] Transitioned to $_currentWizardStep (waitingUserConfirmation)',
+      );
     }
   }
 
-  /// 現在の進捗率を計算（0.0 ~ 1.0）
+  /// ウィザード全体の進捗率の計算 (0.0 ~ 1.0)
   double get _progressValue {
-    if (_isCompleted) return 1.0;
+    if (_currentWizardStep == WizardStep.publication &&
+        _currentStepStatus == StepStatus.success) {
+      return 1.0;
+    }
 
-    final displayStep = _hasError ? _lastStepBeforeError : _currentStep;
-    final currentIndex = displayStep.stepIndex;
-    if (currentIndex < 0) return 0.0;
+    final currentStepIndex = _currentWizardStep.stepIndex;
+    double stepBaseProgress = currentStepIndex / WizardStep.values.length;
 
-    return (currentIndex + 1) / _allSteps.length;
+    double statusProgress = 0.0;
+    if (_currentStepStatus == StepStatus.success) {
+      statusProgress = 1.0 / WizardStep.values.length;
+    } else if (_currentStepStatus == StepStatus.running) {
+      if (_currentWizardStep == WizardStep.provisioning) {
+        final subStepIndex = _currentStep.stepIndex;
+        if (subStepIndex >= 0) {
+          statusProgress =
+              (subStepIndex + 1) /
+              (ProvisioningStep.values.length - 1) /
+              WizardStep.values.length;
+        }
+      } else {
+        statusProgress = 0.5 / WizardStep.values.length;
+      }
+    }
+
+    return (stepBaseProgress + statusProgress).clamp(0.0, 1.0);
   }
 
   @override
   Widget build(BuildContext context) {
+    final isFinished =
+        _currentWizardStep == WizardStep.publication &&
+        _currentStepStatus == StepStatus.success;
+    final isFailed = _currentStepStatus == StepStatus.failed;
+
     return PopScope(
-      canPop: _isCompleted || _hasError,
+      canPop: isFinished || isFailed,
       child: Dialog(
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(16.0),
@@ -233,26 +495,35 @@ class _ProvisioningProgressDialogState
       value: _progressValue,
       backgroundColor: Colors.grey[300],
       valueColor: AlwaysStoppedAnimation<Color>(
-        _hasError ? Colors.red : Colors.blue,
+        _currentStepStatus == StepStatus.failed ? Colors.red : Colors.blue,
       ),
       minHeight: 8,
     );
   }
 
-  /// ステップインジケーター
+  /// ウィザード各ステップのインジケーター表示
   Widget _buildStepIndicators() {
-    // エラー時はエラー前のステップを基準にする
-    final displayStep = _hasError ? _lastStepBeforeError : _currentStep;
-
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       children:
-          _allSteps.map((step) {
-            final isActive = step.stepIndex <= displayStep.stepIndex;
-            final isCurrent = step == displayStep;
-            // エラー時、エラーが起きたステップを赤で表示
-            final isErrorStep = _hasError && isCurrent;
-            final displayColor = isErrorStep ? Colors.red : step.color;
+          WizardStep.values.map((step) {
+            final isCompleted =
+                step.stepIndex < _currentWizardStep.stepIndex ||
+                (_currentWizardStep == step &&
+                    _currentStepStatus == StepStatus.success);
+            final isActive = _currentWizardStep == step;
+            final isFailed =
+                _currentWizardStep == step &&
+                _currentStepStatus == StepStatus.failed;
+
+            final displayColor =
+                isFailed
+                    ? Colors.red
+                    : isCompleted
+                    ? Colors.green
+                    : isActive
+                    ? Colors.blue
+                    : Colors.grey;
 
             return Expanded(
               child: Column(
@@ -263,18 +534,21 @@ class _ProvisioningProgressDialogState
                     decoration: BoxDecoration(
                       shape: BoxShape.circle,
                       color:
-                          isActive || isCurrent
+                          isActive || isCompleted
                               ? displayColor.withValues(alpha: 0.2)
                               : Colors.grey[300],
                       border: Border.all(
-                        color:
-                            isActive || isCurrent ? displayColor : Colors.grey,
-                        width: isCurrent ? 3 : 2,
+                        color: displayColor,
+                        width: isActive ? 3 : 2,
                       ),
                     ),
                     child: Icon(
-                      isErrorStep ? Icons.error : step.icon,
-                      color: isActive || isCurrent ? displayColor : Colors.grey,
+                      isFailed
+                          ? Icons.error
+                          : isCompleted
+                          ? Icons.check
+                          : step.icon,
+                      color: displayColor,
                       size: 24,
                     ),
                   ),
@@ -284,8 +558,9 @@ class _ProvisioningProgressDialogState
                     style: TextStyle(
                       fontSize: 10,
                       fontWeight:
-                          isCurrent ? FontWeight.bold : FontWeight.normal,
-                      color: isActive || isCurrent ? Colors.black : Colors.grey,
+                          isActive ? FontWeight.bold : FontWeight.normal,
+                      color:
+                          isActive || isCompleted ? Colors.black : Colors.grey,
                     ),
                     textAlign: TextAlign.center,
                   ),
@@ -296,9 +571,9 @@ class _ProvisioningProgressDialogState
     );
   }
 
-  /// ステータスメッセージ（エラー / 完了 / 進行中）
+  /// ステータスメッセージ表示エリア
   Widget _buildStatusMessage() {
-    if (_hasError) {
+    if (_currentStepStatus == StepStatus.failed) {
       return Container(
         padding: const EdgeInsets.all(12),
         decoration: BoxDecoration(
@@ -321,7 +596,7 @@ class _ProvisioningProgressDialogState
       );
     }
 
-    if (_isCompleted) {
+    if (_currentStepStatus == StepStatus.success) {
       return Container(
         padding: const EdgeInsets.all(12),
         decoration: BoxDecoration(
@@ -344,37 +619,104 @@ class _ProvisioningProgressDialogState
       );
     }
 
-    return Row(
-      children: [
-        const SizedBox(
-          width: 20,
-          height: 20,
-          child: CircularProgressIndicator(strokeWidth: 2),
-        ),
-        const SizedBox(width: 12),
-        Expanded(
-          child: Text(_statusMessage, style: const TextStyle(fontSize: 14)),
-        ),
-      ],
+    if (_currentStepStatus == StepStatus.running) {
+      return Row(
+        children: [
+          const SizedBox(
+            width: 20,
+            height: 20,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(_statusMessage, style: const TextStyle(fontSize: 14)),
+          ),
+        ],
+      );
+    }
+
+    // waitingUserConfirmation
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.blue[50],
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: Colors.blue),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.info, color: Colors.blue),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              _statusMessage,
+              style: const TextStyle(color: Colors.blue, fontSize: 14),
+            ),
+          ),
+        ],
+      ),
     );
   }
 
-  /// アクションボタン（完了/閉じる）
+  /// アクションボタン表示
   Widget _buildActionButton() {
-    if (!_isCompleted && !_hasError) {
-      return const SizedBox.shrink();
+    if (_currentStepStatus == StepStatus.running) {
+      return const SizedBox.shrink(); // 実行中はボタンを表示しない
     }
 
-    return SizedBox(
-      width: double.infinity,
-      child: ElevatedButton(
-        onPressed: () => Navigator.of(context).pop(),
-        style: ElevatedButton.styleFrom(
-          backgroundColor: _hasError ? Colors.red : Colors.blue,
-          foregroundColor: Colors.white,
+    if (_currentStepStatus == StepStatus.waitingUserConfirmation) {
+      return SizedBox(
+        width: double.infinity,
+        child: ElevatedButton(
+          onPressed: _triggerStepAction,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.blue,
+            foregroundColor: Colors.white,
+          ),
+          child: const Text('YES'),
         ),
-        child: Text(_hasError ? '閉じる' : '完了'),
-      ),
-    );
+      );
+    }
+
+    if (_currentStepStatus == StepStatus.success) {
+      final isLastStep = _currentWizardStep == WizardStep.publication;
+      return SizedBox(
+        width: double.infinity,
+        child: ElevatedButton(
+          onPressed: _handleNextStep,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.blue,
+            foregroundColor: Colors.white,
+          ),
+          child: Text(isLastStep ? '完了' : 'NEXT'),
+        ),
+      );
+    }
+
+    if (_currentStepStatus == StepStatus.failed) {
+      return Row(
+        children: [
+          Expanded(
+            child: OutlinedButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('閉じる'),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: ElevatedButton(
+              onPressed: _triggerStepAction,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.red,
+                foregroundColor: Colors.white,
+              ),
+              child: const Text('Retry'),
+            ),
+          ),
+        ],
+      );
+    }
+
+    return const SizedBox.shrink();
   }
 }


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

### 概要 & 関連資料
<!-- issue番号を # の後に入れると PR merge 時に close される -->
- close #99 

### 変更内容

- **1 Push Provisioning (一括自動設定) のシーケンス構築**
  - Provisioning完了後、自動的にGATT Proxy接続へ移行し、`AppKey追加` → `Composition Data取得` → `Model App Bind` → `Subscription (購読) 設定` → `Publication (送信) 設定` までを途切れることなく1クリックで完結させるフローを実装しました（`ConfigurationService.swift`）。
  - 各コマンド送信後、デバイスからの `ACK (Statusメッセージ)` 受信をトリガーにして次の工程へ自動遷移するステートマシンを構築しました。
- **通信タイムアウトとフェイルセーフ機構 (Watchdog) の実装**
  - Swift側に15秒（5秒×3Tick）の Watchdog タイマーを実装。デバイスからの応答が途切れた場合にタイムアウトとして検知し、Flutter側へイベントを通知してシーケンスを安全に中断する仕組みを導入しました。
  - GATT Proxy スキャン時（`WAIT_PROXY_CONNECTION`）における無限スキャン待機を防ぐため、専用の30秒タイムアウト処理を追加しました。
- **冪等性（Idempotency）と自動レジューム（Retry）の確立**
  - 途中で通信エラーやデバイスの電源断が発生しても、「Retry」ボタンから失敗した箇所・未完了の箇所から安全に設定を再開（自動レジューム）できる設計としました。
  - 厳格なUUID照合（大文字・小文字の区別排除）と、Flutter側の「真のMesh UUID」の保持・上書きロジックにより、既存ノード検知時はプロビジョニングをスキップしてProxy接続から再開するように修正しました。
  - Bluetooth Meshプロトコル本来の冪等性（重複して設定を送信してもSuccessが返る仕様）を活かし、ローカルDBへの過信による手動スキップ処理を撤去し、DBとデバイスの不整合を防ぎました。
- **Flutter側の状態管理の委譲とコードクリーンアップ**
  - Flutter（Dart）側に存在していた不安定なタイムアウト処理（Timer）を完全に撤去し、状態管理・エラー判定の全権限をネイティブ（Swift）側へ委譲・一元化しました。
  - 一時的なデバッグ用 `print` や、コメントアウトされた不要な過去のコードブロックを一掃し、コードベースをクリーンアップしました。
- **構造化ロギング (`MeshTrace.log`) の導入**
  - 処理の実行時間（ACKのラウンドトリップ）や状態遷移、フィルタ更新などを詳細に記録する構造化ログを導入し、今後の運用・トラブルシューティングの追跡を容易にしました。

### 影響範囲

- **iOS ネイティブ層（Bluetooth Mesh 通信）**
  - `AppDelegate.swift`, `AppDelegate+MeshNetworkDelegate.swift`: イベント通知、状態管理、Proxyスキャン、ACK受信ハンドリング。
  - `ProvisioningService.swift`, `ConfigurationService.swift`: 一括設定の進行ロジック、自動レジューム機能、Watchdogタイマー。
- **Flutter UI層**
  - `provisioning_progress_dialog.dart`: 各プロビジョニング・設定ステップの進捗UI表示、SwiftからのEventChannel経由のエラー検知、Retryボタンのアクション。

### 備考

- 本機能により、物理的なFactory Resetを行わなくても、通信失敗時に「Retryボタンを押すだけ」で最終的な設定完了ステータスへ到達できるようになりました。
- ローカルDBの永続化タイミング（`meshNetworkManager.save()`）を各処理の完了直後に徹底したことで、アプリ再起動時やクラッシュ時のデータロスト耐性も向上しています。
ーーーーー
### セルフチェック
- [x] 環境変数などがPRに含まれていないか

<!-- I want to review in Japanese. -->
