### PR TITLE
[FEAT]: 新基盤（nRF54L15DK）上のVendor Modelにメッセージを送信する機能を実装

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -174,6 +174,11 @@ enum MeshState: String {
                     sigModelId: .genericColorClientModelID,
                     delegate: GenericColorClientDelegate()
                 ),
+                Model(
+                    vendorModelId: 0x0001,
+                    companyId: 0x0059,
+                    delegate: VendorColorClientDelegate()
+                )
             ]
         )
         meshNetworkManager.localElements = [primaryElement]

--- a/ios/Runner/Bluetooth/AppDelegate+MeshNetworkDelegate.swift
+++ b/ios/Runner/Bluetooth/AppDelegate+MeshNetworkDelegate.swift
@@ -482,25 +482,29 @@ extension AppDelegate: MeshNetworkDelegate {
         
         meshState = .configuring
 
-        let clientUnicastAddress = Address(0x0001)
-        var serverModel: Model?
-        var clientModelID: UInt16?
-
         let models = node.elements.flatMap({ $0.models })
+        ConfigurationService.shared.pendingModelsToBind.removeAll()
 
+        // 全ての必要なサーバモデルを収集する
         if let genericOnOffServerModel = models.first(where: {
-            UInt16($0.modelId) == .genericOnOffServerModelId
+            $0.modelIdentifier == .genericOnOffServerModelId && $0.companyIdentifier == nil
         }) {
-            serverModel = genericOnOffServerModel
-            clientModelID = .genericOnOffClientModelId
+            ConfigurationService.shared.pendingModelsToBind.append(genericOnOffServerModel)
         }
-        else if let genericColorServerModel = models.first(where: {
-            UInt16($0.modelId) == .genericColorServerModelID
+        
+        if let genericColorServerModel = models.first(where: {
+            $0.modelIdentifier == .genericColorServerModelID && $0.companyIdentifier == nil
         }) {
-            serverModel = genericColorServerModel
-            clientModelID = .genericColorClientModelID
+            ConfigurationService.shared.pendingModelsToBind.append(genericColorServerModel)
         }
-        else {
+
+        if let vendorModel = models.first(where: {
+            $0.modelIdentifier == UInt16(0x0001) && $0.companyIdentifier == UInt16(0x0059)
+        }) {
+            ConfigurationService.shared.pendingModelsToBind.append(vendorModel)
+        }
+
+        if ConfigurationService.shared.pendingModelsToBind.isEmpty {
             let detail = "Valid server model not found"
             MeshTrace.log(
                 traceId: traceIdStr,
@@ -519,19 +523,54 @@ extension AppDelegate: MeshNetworkDelegate {
             return
         }
 
-        bindModel(
-            model: serverModel!,
-            appKey: appKey,
-            manager: manager,
-            node: node
-        )
+        bindNextModel(appKey: appKey, manager: manager, node: node)
+    }
 
-        guard
-            let clientModel = manager.localElements
-                .flatMap({ $0.models })
-                .first(where: {
-                    $0.modelIdentifier == clientModelID
-                })
+    private func bindNextModel(appKey: ApplicationKey, manager: MeshNetworkManager, node: Node) {
+        let traceIdStr = ConfigurationService.shared.configTraceId?.uuidString ?? "N/A"
+        guard let serverModel = ConfigurationService.shared.pendingModelsToBind.first else {
+            // 全てのモデルのバインドが完了
+            sendFlutterEvent(
+                status: .success,
+                message: "Successfully bound AppKeys to all Models",
+                eventType: "configuration"
+            )
+            
+            if !ConfigurationService.shared.isSubscribed {
+                meshState = .subscription
+                let result = ConfigurationService.shared.setSubscription(withAddress: node.primaryUnicastAddress)
+                
+                let triggerDetail = "Subscription triggered: \(result.isSuccess) - \(result.message)"
+                MeshTrace.log(
+                    traceId: traceIdStr,
+                    step: "SUBSCRIPTION",
+                    event: "TRIGGER",
+                    node: "\(node.primaryUnicastAddress)",
+                    state: meshState.rawValue,
+                    detail: triggerDetail
+                )
+            }
+            return
+        }
+
+        // 対応するクライアントモデルを探す
+        var clientModelID: UInt16?
+        var clientCompanyID: UInt16?
+
+        if serverModel.modelIdentifier == .genericOnOffServerModelId && serverModel.companyIdentifier == nil {
+            clientModelID = .genericOnOffClientModelId
+        } else if serverModel.modelIdentifier == .genericColorServerModelID && serverModel.companyIdentifier == nil {
+            clientModelID = .genericColorClientModelID
+        } else if serverModel.modelIdentifier == UInt16(0x0001) && serverModel.companyIdentifier == UInt16(0x0059) {
+            clientModelID = UInt16(0x0001)
+            clientCompanyID = UInt16(0x0059)
+        }
+
+        let clientUnicastAddress = Address(0x0001)
+        guard let cId = clientModelID,
+              let clientModel = manager.localElements.flatMap({ $0.models }).first(where: {
+                  $0.modelIdentifier == cId && $0.companyIdentifier == clientCompanyID
+              })
         else {
             let detail = "Failed to find client model"
             MeshTrace.log(
@@ -545,61 +584,38 @@ extension AppDelegate: MeshNetworkDelegate {
             ConfigurationService.shared.stopWatchdog()
             return
         }
-        do {
-            guard
-                let clientBindMessage = ConfigModelAppBind(
-                    applicationKey: appKey,
-                    to: clientModel
-                )
-            else {
-                let detail = "Failed to create client-model-bind message"
+
+        // クライアントモデル（ローカル）にAppKeyをバインドする（ハンドラは上書きしない）
+        if let clientBindMessage = ConfigModelAppBind(applicationKey: appKey, to: clientModel) {
+            do {
+                _ = try manager.send(clientBindMessage, to: clientUnicastAddress)
                 MeshTrace.log(
                     traceId: traceIdStr,
                     step: "MODEL_APP_BIND",
-                    event: "CLIENT_MESSAGE_ERROR",
+                    event: "SEND_POST_CLIENT_SUCCESS",
                     node: "\(clientUnicastAddress)",
                     state: meshState.rawValue,
-                    detail: detail
+                    detail: "Sent local Client Model Bind successfully."
                 )
-                ConfigurationService.shared.stopWatchdog()
-                return
+            } catch {
+                MeshTrace.log(
+                    traceId: traceIdStr,
+                    step: "MODEL_APP_BIND",
+                    event: "SEND_POST_CLIENT_FAILURE",
+                    node: "\(clientUnicastAddress)",
+                    state: meshState.rawValue,
+                    detail: "Failed to send local Client Model Bind: \(error.localizedDescription)"
+                )
             }
-            
-            let detailSendPre = "Sending local Client Model Bind (ID: \(clientModel.modelIdentifier)) to ClientUnicastAddress: \(clientUnicastAddress)"
-            MeshTrace.log(
-                traceId: traceIdStr,
-                step: "MODEL_APP_BIND",
-                event: "SEND_PRE_CLIENT",
-                node: "\(clientUnicastAddress)",
-                state: meshState.rawValue,
-                detail: detailSendPre
-            )
-            
-            ConfigurationService.shared.trackAckSent(messageType: "ConfigModelAppBind")
-            ConfigurationService.shared.currentMessageHandle = try manager.send(clientBindMessage, to: clientUnicastAddress)
-
-            let detailSendPost = "Sent local Client Model Bind successfully."
-            MeshTrace.log(
-                traceId: traceIdStr,
-                step: "MODEL_APP_BIND",
-                event: "SEND_POST_CLIENT_SUCCESS",
-                node: "\(clientUnicastAddress)",
-                state: meshState.rawValue,
-                detail: detailSendPost
-            )
-        } catch {
-            let detailSendFail = "Failed to send local Client Model Bind: \(error.localizedDescription)"
-            MeshTrace.log(
-                traceId: traceIdStr,
-                step: "MODEL_APP_BIND",
-                event: "SEND_POST_CLIENT_FAILURE",
-                node: "\(clientUnicastAddress)",
-                state: meshState.rawValue,
-                detail: detailSendFail
-            )
-            ConfigurationService.shared.stopWatchdog()
-            return
         }
+
+        // サーバーモデル（リモート）にAppKeyをバインドする
+        bindModel(
+            model: serverModel,
+            appKey: appKey,
+            manager: manager,
+            node: node
+        )
     }
 
     private func bindModel(
@@ -663,7 +679,7 @@ extension AppDelegate: MeshNetworkDelegate {
         let traceIdStr = ConfigurationService.shared.configTraceId?.uuidString ?? "N/A"
         if modelAppStatus.status == .success {
             _ = manager.save()
-            let detail = "Successfully bind AppKey to Model. Transitioning to subscription."
+            let detail = "Successfully bound AppKey to Model. Checking for pending models..."
             MeshTrace.log(
                 traceId: traceIdStr,
                 step: "MODEL_APP_BIND",
@@ -673,25 +689,23 @@ extension AppDelegate: MeshNetworkDelegate {
                 detail: detail
             )
             
-            sendFlutterEvent(
-                status: .success,
-                message: "Successfully bind AppKey to Model",
-                eventType: "configuration"
-            )
+            if !ConfigurationService.shared.pendingModelsToBind.isEmpty {
+                ConfigurationService.shared.pendingModelsToBind.removeFirst()
+            }
             
-            if !ConfigurationService.shared.isSubscribed {
-                meshState = .subscription
-                let result = ConfigurationService.shared.setSubscription(withAddress: node.primaryUnicastAddress)
+            if !ConfigurationService.shared.pendingModelsToBind.isEmpty {
+                // 次のモデルのバインドへ進む
+                guard let appKey = manager.meshNetwork?.applicationKeys.first(where: {
+                    node.knows(networkKey: $0.boundNetworkKey)
+                }) else { return }
                 
-                let triggerDetail = "Subscription triggered: \(result.isSuccess) - \(result.message)"
-                MeshTrace.log(
-                    traceId: traceIdStr,
-                    step: "SUBSCRIPTION",
-                    event: "TRIGGER",
-                    node: "\(node.primaryUnicastAddress)",
-                    state: meshState.rawValue,
-                    detail: triggerDetail
-                )
+                // 次のACK待ちのためのタイマー延長などは bindNextModel の bindModel で上書きされる
+                ConfigurationService.shared.expectedNextEvent = "ConfigModelAppStatus"
+                ConfigurationService.shared.expectedDelegate = "ConfigModelAppStatus"
+                bindNextModel(appKey: appKey, manager: manager, node: node)
+            } else {
+                // 全てのバインドが終了
+                bindNextModel(appKey: manager.meshNetwork!.applicationKeys.first!, manager: manager, node: node)
             }
         } else {
             let detail = "Model bind failed with status: \(modelAppStatus.status)"

--- a/ios/Runner/Bluetooth/ConfigurationService.swift
+++ b/ios/Runner/Bluetooth/ConfigurationService.swift
@@ -44,6 +44,8 @@ class ConfigurationService {
     var pendingAckMessage: String?
     var pendingAckSentTime: Date?
     var proxyFilterUpdatedCount = 0
+    var pendingModelsToBind: [Model] = []
+    
     private var watchdogTimer: Timer?
     private var watchdogTicks = 0
     private let maxWatchdogTicks = 3
@@ -242,6 +244,7 @@ class ConfigurationService {
         var node: Node!
         var serverModel: Model!
         var clientModelID: UInt16?
+        var clientCompanyID: UInt16?
         var targetGroup: Group?
 
         // ノードを探す
@@ -266,15 +269,21 @@ class ConfigurationService {
         // サーバーモデルを探す
         let models = node.elements.flatMap({ $0.models })
         if let genericOnOffServerModel = models.first(where: {
-            $0.modelIdentifier == .genericOnOffServerModelId
+            $0.modelIdentifier == .genericOnOffServerModelId && $0.companyIdentifier == nil
         }) {
             serverModel = genericOnOffServerModel
             clientModelID = .genericOnOffClientModelId
         } else if let genericColorServerModel = models.first(where: {
-            $0.modelIdentifier == .genericColorServerModelID
+            $0.modelIdentifier == .genericColorServerModelID && $0.companyIdentifier == nil
         }) {
             serverModel = genericColorServerModel
             clientModelID = .genericColorClientModelID
+        } else if let vendorColorServerModel = models.first(where: {
+            $0.modelIdentifier == UInt16(0x0001) && $0.companyIdentifier == UInt16(0x0059)
+        }) {
+            serverModel = vendorColorServerModel
+            clientModelID = UInt16(0x0001)
+            clientCompanyID = UInt16(0x0059)
         } else {
             let detailErr = "setSubscription failed: Couldn't find server model for address \(address)"
             MeshTrace.log(
@@ -291,10 +300,10 @@ class ConfigurationService {
             )
         }
 
-        guard let clientModelID,
+        guard let clientID = clientModelID,
             manager.localElements
                 .flatMap({ $0.models })
-                .first(where: { $0.modelIdentifier == clientModelID }) != nil
+                .first(where: { $0.modelIdentifier == clientID && $0.companyIdentifier == clientCompanyID }) != nil
         else {
             let detailErr = "setSubscription failed: Failed to find client model \(clientModelID)"
             MeshTrace.log(
@@ -446,6 +455,7 @@ class ConfigurationService {
         var node: Node!
         var serverModel: Model!
         var clientModelID: UInt16?
+        var clientCompanyID: UInt16?
 
         // ノードを探す
         do {
@@ -470,15 +480,21 @@ class ConfigurationService {
         // サーバーモデルを探す
         let models = node.elements.flatMap({ $0.models })
         if let genericOnOffServerModel = models.first(where: {
-            $0.modelIdentifier == .genericOnOffServerModelId
+            $0.modelIdentifier == .genericOnOffServerModelId && $0.companyIdentifier == nil
         }) {
             serverModel = genericOnOffServerModel
             clientModelID = .genericOnOffClientModelId
         } else if let genericColorServerModel = models.first(where: {
-            $0.modelIdentifier == .genericColorServerModelID
+            $0.modelIdentifier == .genericColorServerModelID && $0.companyIdentifier == nil
         }) {
             serverModel = genericColorServerModel
             clientModelID = .genericColorClientModelID
+        } else if let vendorColorServerModel = models.first(where: {
+            $0.modelIdentifier == UInt16(0x0001) && $0.companyIdentifier == UInt16(0x0059)
+        }) {
+            serverModel = vendorColorServerModel
+            clientModelID = UInt16(0x0001)
+            clientCompanyID = UInt16(0x0059)
         } else {
             let detailErr = "setPublication failed: Couldn't find server model for address \(address)"
             MeshTrace.log(
@@ -496,9 +512,9 @@ class ConfigurationService {
             )
         }
 
-        guard let clientModelID,
+        guard let clientID = clientModelID,
             let clientModel = manager.localElements.flatMap({ $0.models })
-                .first(where: { $0.modelIdentifier == clientModelID })
+                .first(where: { $0.modelIdentifier == clientID && $0.companyIdentifier == clientCompanyID })
         else {
             let detailErr = "setPublication failed: Failed to find client model \(clientModelID)"
             MeshTrace.log(

--- a/ios/Runner/FlutterChannels/FlutterChannelManager.swift
+++ b/ios/Runner/FlutterChannels/FlutterChannelManager.swift
@@ -140,17 +140,17 @@ class FlutterChannelManager {
         case "resetNode":
             // パラメータに `unicastAddress` が含まれているかを確認
             guard let args = call.arguments as? [String: Any],
-                let unicastAddress = args["unicastAddress"]
+                let unicastAddressInt = args["unicastAddress"] as? Int
             else {
                 handleMethodResponse(
                     result: result,
                     isSuccess: false,
-                    message: "unicastAddress not found in arguments."
+                    message: "unicastAddress not found or invalid type."
                 )
                 return
             }
             let response = ConfigurationService.shared.resetNode(
-                unicastAddress: unicastAddress as! Address
+                unicastAddress: Address(unicastAddressInt)
             )
             handleMethodResponse(
                 result: result,
@@ -161,18 +161,18 @@ class FlutterChannelManager {
         case "configureNode":
             // パラメータに `unicastAddress` が含まれているかを確認
             guard let args = call.arguments as? [String: Any],
-                let unicastAddress = args["unicastAddress"]
+                let unicastAddressInt = args["unicastAddress"] as? Int
             else {
                 handleMethodResponse(
                     result: result,
                     isSuccess: false,
-                    message: "unicastAddress not found in arguments."
+                    message: "unicastAddress not found or invalid type."
                 )
                 return
             }
 
             let response = ConfigurationService.shared.configureNode(
-                unicastAddress: unicastAddress as! Address
+                unicastAddress: Address(unicastAddressInt)
             )
             handleMethodResponse(
                 result: result,
@@ -183,18 +183,18 @@ class FlutterChannelManager {
         case "setSubscription":
             // パラメータに `unicastAddress` が含まれているか確認
             guard let args = call.arguments as? [String: Any],
-                let unicastAddress = args["unicastAddress"] as? Address
+                let unicastAddressInt = args["unicastAddress"] as? Int
             else {
                 handleMethodResponse(
                     result: result,
                     isSuccess: false,
-                    message: "unicastAddress not found in arguments."
+                    message: "unicastAddress not found or invalid type."
                 )
                 return
             }
 
             let response = ConfigurationService.shared.setSubscription(
-                withAddress: unicastAddress
+                withAddress: Address(unicastAddressInt)
             )
             handleMethodResponse(
                 result: result,
@@ -204,12 +204,12 @@ class FlutterChannelManager {
 
         case "setPublication":
             guard let args = call.arguments as? [String: Any],
-                let unicastAddress = args["unicastAddress"] as? Address
+                let unicastAddressInt = args["unicastAddress"] as? Int
             else {
                 handleMethodResponse(
                     result: result,
                     isSuccess: false,
-                    message: "unicastAddress not found in arguments."
+                    message: "unicastAddress not found or invalid type."
                 )
                 return
             }
@@ -217,7 +217,7 @@ class FlutterChannelManager {
             print("Received Publication message")
 
             let response = ConfigurationService.shared.setPublication(
-                withAddress: unicastAddress
+                withAddress: Address(unicastAddressInt)
             )
 
             handleMethodResponse(
@@ -255,19 +255,19 @@ class FlutterChannelManager {
         case "genericOnOffSet":
             // パラメータに `unicastAddress`, `state` が含まれているかを確認
             guard let args = call.arguments as? [String: Any],
-                let unicastAddress = args["unicastAddress"] as? Address,
+                let unicastAddressInt = args["unicastAddress"] as? Int,
                 let state = args["state"] as? Bool
             else {
                 handleMethodResponse(
                     result: result,
                     isSuccess: false,
-                    message: "unicastAddress or state not found"
+                    message: "unicastAddress or state not found or invalid type"
                 )
                 return
             }
 
             let response = MeshNetworkService.shared.setGenericOnOffState(
-                unicastAddress: unicastAddress,
+                unicastAddress: Address(unicastAddressInt),
                 state: state
             )
             handleMethodResponse(
@@ -279,19 +279,19 @@ class FlutterChannelManager {
         case "genericColorSet":
             // パラメータに `unicastAddress`, `color` が含まれているかを確認
             guard let args = call.arguments as? [String: Any],
-                let unicastAddress = args["unicastAddress"] as? Address,
+                let unicastAddressInt = args["unicastAddress"] as? Int,
                 let color = args["color"] as? Int
             else {
                 handleMethodResponse(
                     result: result,
                     isSuccess: false,
-                    message: "unicastAddress or color not found"
+                    message: "unicastAddress or color not found or invalid type"
                 )
                 return
             }
 
             let response = MeshNetworkService.shared.setGenericColorState(
-                unicastAddress: unicastAddress,
+                unicastAddress: Address(unicastAddressInt),
                 state: color
             )
             handleMethodResponse(
@@ -302,19 +302,19 @@ class FlutterChannelManager {
 
         case "vendorColorSet":
             guard let args = call.arguments as? [String: Any],
-                let unicastAddress = args["unicastAddress"] as? Address,
+                let unicastAddressInt = args["unicastAddress"] as? Int,
                 let colorArray = args["colorArray"] as? [Int]
             else {
                 handleMethodResponse(
                     result: result,
                     isSuccess: false,
-                    message: "unicastAddress or colorArray not found"
+                    message: "unicastAddress or colorArray not found or invalid type"
                 )
                 return
             }
 
             let response = MeshNetworkService.shared.setVendorColorState(
-                unicastAddress: unicastAddress,
+                unicastAddress: Address(unicastAddressInt),
                 colorArray: colorArray.map { UInt8($0) }
             )
             handleMethodResponse(

--- a/ios/Runner/FlutterChannels/FlutterChannelManager.swift
+++ b/ios/Runner/FlutterChannels/FlutterChannelManager.swift
@@ -300,6 +300,29 @@ class FlutterChannelManager {
                 message: response.message ?? "No message provided"
             )
 
+        case "vendorColorSet":
+            guard let args = call.arguments as? [String: Any],
+                let unicastAddress = args["unicastAddress"] as? Address,
+                let colorArray = args["colorArray"] as? [Int]
+            else {
+                handleMethodResponse(
+                    result: result,
+                    isSuccess: false,
+                    message: "unicastAddress or colorArray not found"
+                )
+                return
+            }
+
+            let response = MeshNetworkService.shared.setVendorColorState(
+                unicastAddress: unicastAddress,
+                colorArray: colorArray.map { UInt8($0) }
+            )
+            handleMethodResponse(
+                result: result,
+                isSuccess: response.isSuccess,
+                message: response.message ?? "No message provided"
+            )
+
         case "publishColor":
             guard let args = call.arguments as? [String: Any],
                 let color = args["color"] as? Int

--- a/ios/Runner/MeshNetwork/MeshNetworkService.swift
+++ b/ios/Runner/MeshNetwork/MeshNetworkService.swift
@@ -179,6 +179,73 @@ class MeshNetworkService {
         )
     }
 
+    func setVendorColorState(unicastAddress: Address, colorArray: [UInt8])
+        -> MeshNetworkServiceResponse
+    {
+        var node: Node?
+
+        // ノードを探す
+        do {
+            node = try findNode(withUnicastAddress: unicastAddress)
+        } catch {
+            return MeshNetworkServiceResponse(
+                isSuccess: false,
+                message: "Failed to find node."
+            )
+        }
+
+        // clientモデルを探す
+        guard
+            let clientModel = manager.localElements
+                .flatMap({ $0.models })
+                .first(where: {
+                    $0.modelIdentifier == UInt16(0x0001) && $0.companyIdentifier == UInt16(0x0059)
+                })
+        else {
+            return MeshNetworkServiceResponse(
+                isSuccess: false,
+                message: "Failed to find client model"
+            )
+        }
+
+        // serverモデルを探す
+        guard let node,
+            let serverModel = node.elements
+                .flatMap({ $0.models })
+                .first(where: {
+                    $0.modelIdentifier == UInt16(0x0001) && $0.companyIdentifier == UInt16(0x0059)
+                })
+        else {
+            return MeshNetworkServiceResponse(
+                isSuccess: false,
+                message: "Failed to find server model"
+            )
+        }
+
+        // メッセージを作成
+        let message = VendorColorSet(colors: colorArray)
+
+        // 送信
+        do {
+            try manager.send(
+                message,
+                from: clientModel,
+                to: serverModel,
+                withTtl: UInt8(3)
+            )
+        } catch {
+            return MeshNetworkServiceResponse(
+                isSuccess: false,
+                message: "Failed to send vendor message: \(error.localizedDescription)"
+            )
+        }
+
+        return MeshNetworkServiceResponse(
+            isSuccess: true,
+            message: "Successfully send vendor message!"
+        )
+    }
+
     func changeAllNodeColor(colorNum: Int) -> MeshNetworkServiceResponse {
         let colorCode = convertColorCode(fromColorNum: colorNum)
         let message = GenericColorSetUnacknowleged(

--- a/ios/Runner/MeshNetwork/VendorColorClientDelegate.swift
+++ b/ios/Runner/MeshNetwork/VendorColorClientDelegate.swift
@@ -1,0 +1,65 @@
+//
+//  VendorColorClientDelegate.swift
+//  Runner
+//
+
+import Foundation
+import NordicMesh
+
+class VendorColorClientDelegate: ModelDelegate {
+
+    let messageTypes: [UInt32: MeshMessage.Type]
+    let isSubscriptionSupported: Bool = true
+
+    var publicationMessageComposer: MessageComposer? {
+        func compose() -> MeshMessage {
+            return VendorColorSet(colors: self.state)
+        }
+        let request = compose()
+        return {
+            return request
+        }
+    }
+
+    var state: [UInt8] = Array(repeating: 0, count: 12) {
+        didSet {
+            publish(using: MeshNetworkManager.instance)
+        }
+    }
+
+    init() {
+        let types: [StaticMeshMessage.Type] = [
+            VendorColorStatus.self
+        ]
+        messageTypes = types.toMap()
+    }
+
+    // MARK: - Message handlers
+
+    func model(
+        _ model: Model,
+        didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage,
+        from source: Address,
+        sentTo destination: MeshAddress
+    ) -> MeshResponse {
+        fatalError("Not possible")
+    }
+
+    func model(
+        _ model: Model,
+        didReceiveUnacknowledgedMessage message: UnacknowledgedMeshMessage,
+        from source: Address,
+        sentTo destination: MeshAddress
+    ) {
+        // Ignore
+    }
+
+    func model(
+        _ model: Model,
+        didReceiveResponse response: MeshResponse,
+        toAcknowledgedMessage request: AcknowledgedMeshMessage,
+        from source: Address
+    ) {
+        // Ignore
+    }
+}

--- a/ios/Runner/MeshNetwork/VendorColorSet.swift
+++ b/ios/Runner/MeshNetwork/VendorColorSet.swift
@@ -1,0 +1,27 @@
+//
+//  VendorColorSet.swift
+//  Runner
+//
+
+import Foundation
+import NordicMesh
+
+public struct VendorColorSet: StaticAcknowledgedVendorMessage {
+    public static let opCode: UInt32 = 0xC15900
+    public static let responseType: StaticMeshResponse.Type = VendorColorStatus.self
+
+    public var parameters: Data? {
+        return Data(colors)
+    }
+
+    public let colors: [UInt8]
+
+    public init(colors: [UInt8]) {
+        self.colors = colors
+    }
+
+    public init?(parameters: Data) {
+        guard parameters.count == 12 else { return nil }
+        self.colors = Array(parameters)
+    }
+}

--- a/ios/Runner/MeshNetwork/VendorColorStatus.swift
+++ b/ios/Runner/MeshNetwork/VendorColorStatus.swift
@@ -1,0 +1,26 @@
+//
+//  VendorColorStatus.swift
+//  Runner
+//
+
+import Foundation
+import NordicMesh
+
+public struct VendorColorStatus: StaticVendorMessage, StaticMeshResponse {
+    public static let opCode: UInt32 = 0xC35900
+
+    public var parameters: Data? {
+        return Data([status])
+    }
+
+    public let status: UInt8
+
+    public init(status: UInt8) {
+        self.status = status
+    }
+
+    public init?(parameters: Data) {
+        guard parameters.count == 1 else { return nil }
+        self.status = parameters[0]
+    }
+}

--- a/lib/features/platform_channels/mesh_network.dart
+++ b/lib/features/platform_channels/mesh_network.dart
@@ -61,6 +61,20 @@ class MeshNetwork {
     return {'isSuccess': isSuccess, 'message': message};
   }
 
+  /// VendorColorSetの状態を変更するメソッド (nRF54用)
+  static Future<Map<String, dynamic>> vendorColorSet({
+    required int unicastAddress,
+    required List<int> colorArray,
+  }) async {
+    final response = await _methodChannel.invokeMethod('vendorColorSet', {
+      'unicastAddress': unicastAddress,
+      'colorArray': colorArray,
+    });
+    bool isSuccess = response['isSuccess'] ?? false;
+    String message = response['message'] ?? 'No message provided';
+    return {'isSuccess': isSuccess, 'message': message};
+  }
+
   /// colorをpublishするメソッド
   static Future<Map<String, dynamic>> publishColor({required int color}) async {
     final response = await _methodChannel.invokeMethod('publishColor', {

--- a/lib/features/platform_channels/mesh_network.dart
+++ b/lib/features/platform_channels/mesh_network.dart
@@ -38,13 +38,19 @@ class MeshNetwork {
     required int unicastAddress,
     required bool state,
   }) async {
-    final response = await _methodChannel.invokeMethod('genericOnOffSet', {
-      'unicastAddress': unicastAddress,
-      'state': state,
-    });
-    bool isSuccess = response['isSuccess'] ?? false;
-    String message = response['message'] ?? 'No message provided';
-    return {'isSuccess': isSuccess, 'message': message};
+    try {
+      final response = await _methodChannel.invokeMethod('genericOnOffSet', {
+        'unicastAddress': unicastAddress,
+        'state': state,
+      });
+      bool isSuccess = response['isSuccess'] ?? false;
+      String message = response['message'] ?? 'No message provided';
+      return {'isSuccess': isSuccess, 'message': message};
+    } on PlatformException catch (e) {
+      return {'isSuccess': false, 'message': 'PlatformException: ${e.message}'};
+    } catch (e) {
+      return {'isSuccess': false, 'message': 'Unexpected Error: $e'};
+    }
   }
 
   /// GenericColorSetの状態を変更するメソッド
@@ -52,13 +58,19 @@ class MeshNetwork {
     required int unicastAddress,
     required int color,
   }) async {
-    final response = await _methodChannel.invokeMethod('genericColorSet', {
-      'unicastAddress': unicastAddress,
-      'color': color,
-    });
-    bool isSuccess = response['isSuccess'] ?? false;
-    String message = response['message'] ?? 'No message provided';
-    return {'isSuccess': isSuccess, 'message': message};
+    try {
+      final response = await _methodChannel.invokeMethod('genericColorSet', {
+        'unicastAddress': unicastAddress,
+        'color': color,
+      });
+      bool isSuccess = response['isSuccess'] ?? false;
+      String message = response['message'] ?? 'No message provided';
+      return {'isSuccess': isSuccess, 'message': message};
+    } on PlatformException catch (e) {
+      return {'isSuccess': false, 'message': 'PlatformException: ${e.message}'};
+    } catch (e) {
+      return {'isSuccess': false, 'message': 'Unexpected Error: $e'};
+    }
   }
 
   /// VendorColorSetの状態を変更するメソッド (nRF54用)
@@ -66,23 +78,35 @@ class MeshNetwork {
     required int unicastAddress,
     required List<int> colorArray,
   }) async {
-    final response = await _methodChannel.invokeMethod('vendorColorSet', {
-      'unicastAddress': unicastAddress,
-      'colorArray': colorArray,
-    });
-    bool isSuccess = response['isSuccess'] ?? false;
-    String message = response['message'] ?? 'No message provided';
-    return {'isSuccess': isSuccess, 'message': message};
+    try {
+      final response = await _methodChannel.invokeMethod('vendorColorSet', {
+        'unicastAddress': unicastAddress,
+        'colorArray': colorArray,
+      });
+      bool isSuccess = response['isSuccess'] ?? false;
+      String message = response['message'] ?? 'No message provided';
+      return {'isSuccess': isSuccess, 'message': message};
+    } on PlatformException catch (e) {
+      return {'isSuccess': false, 'message': 'PlatformException: ${e.message}'};
+    } catch (e) {
+      return {'isSuccess': false, 'message': 'Unexpected Error: $e'};
+    }
   }
 
   /// colorをpublishするメソッド
   static Future<Map<String, dynamic>> publishColor({required int color}) async {
-    final response = await _methodChannel.invokeMethod('publishColor', {
-      'color': color,
-    });
-    bool isSuccess = response['isSuccess'] ?? false;
-    String message = response['message'] ?? 'No message provided';
-    return {'isSuccess': isSuccess, 'message': message};
+    try {
+      final response = await _methodChannel.invokeMethod('publishColor', {
+        'color': color,
+      });
+      bool isSuccess = response['isSuccess'] ?? false;
+      String message = response['message'] ?? 'No message provided';
+      return {'isSuccess': isSuccess, 'message': message};
+    } on PlatformException catch (e) {
+      return {'isSuccess': false, 'message': 'PlatformException: ${e.message}'};
+    } catch (e) {
+      return {'isSuccess': false, 'message': 'Unexpected Error: $e'};
+    }
   }
 
   /// 各ノードの色を個別に変更するメソッド（for nRF52）
@@ -118,13 +142,19 @@ class MeshNetwork {
       colorNumStrings.substring(8, 12).split('').reversed.join(),
     );
 
-    final response = await _methodChannel.invokeMethod('setNodeColors', {
-      'colorNum': colorNum,
-      'colorNum2': colorNum2,
-      'colorNum3': colorNum3,
-    });
-    bool isSuccess = response['isSuccess'] ?? false;
-    String message = response['message'] ?? 'No message provided';
-    return {'isSuccess': isSuccess, 'message': message};
+    try {
+      final response = await _methodChannel.invokeMethod('setNodeColors', {
+        'colorNum': colorNum,
+        'colorNum2': colorNum2,
+        'colorNum3': colorNum3,
+      });
+      bool isSuccess = response['isSuccess'] ?? false;
+      String message = response['message'] ?? 'No message provided';
+      return {'isSuccess': isSuccess, 'message': message};
+    } on PlatformException catch (e) {
+      return {'isSuccess': false, 'message': 'PlatformException: ${e.message}'};
+    } catch (e) {
+      return {'isSuccess': false, 'message': 'Unexpected Error: $e'};
+    }
   }
 }

--- a/lib/pages/connection_page/network_node_detail.dart
+++ b/lib/pages/connection_page/network_node_detail.dart
@@ -133,7 +133,21 @@ class _NetworkNodeDetailState extends State<NetworkNodeDetail> {
     required int unicastAddress,
     required int color,
   }) async {
-    List<int> colorArray = List.filled(12, color);
+    // 1. 全要素を0で初期化 (最大12ノード)
+    List<int> colorArray = List.filled(12, 0);
+
+    // 2. ユニキャストアドレスから対象インデックスを計算 (ベースアドレス: 2)
+    int targetIndex = unicastAddress - 2;
+
+    // 3. 範囲内の場合のみ、対象デバイスの色を設定
+    if (targetIndex >= 0 && targetIndex <= 11) {
+      colorArray[targetIndex] = color;
+    } else {
+      debugPrint(
+        "Warning: targetIndex $targetIndex is out of bounds (unicastAddress: $unicastAddress)",
+      );
+    }
+
     var response = await MeshNetwork.vendorColorSet(
       unicastAddress: unicastAddress,
       colorArray: colorArray,

--- a/lib/pages/connection_page/network_node_detail.dart
+++ b/lib/pages/connection_page/network_node_detail.dart
@@ -18,6 +18,9 @@ class _NetworkNodeDetailState extends State<NetworkNodeDetail> {
   /// GenericColorSetの状態を保持するための変数
   int colorIndex = 0;
 
+  /// VendorColorSetの状態を保持するための変数
+  int vendorColorIndex = 0;
+
   Future<void> _resetNode({required int unicastAddress}) async {
     // Close the dialog after resetting
     Navigator.of(context).pop();
@@ -120,6 +123,30 @@ class _NetworkNodeDetailState extends State<NetworkNodeDetail> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text('GenericColorSet failed: ${response['message']}'),
+        ),
+      );
+    }
+  }
+
+  /// VendorColorNodeの色を変更するメソッド (nRF54用)
+  Future<void> _vendorColorSet({
+    required int unicastAddress,
+    required int color,
+  }) async {
+    List<int> colorArray = List.filled(12, color);
+    var response = await MeshNetwork.vendorColorSet(
+      unicastAddress: unicastAddress,
+      colorArray: colorArray,
+    );
+    setState(() {
+      vendorColorIndex = color;
+    });
+    if (!mounted) return;
+    if (!response['isSuccess']) {
+      Navigator.of(context).pop();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('VendorColorSet failed: ${response['message']}'),
         ),
       );
     }
@@ -229,6 +256,37 @@ class _NetworkNodeDetailState extends State<NetworkNodeDetail> {
                         colorIndex == 1,
                         colorIndex == 2,
                         colorIndex == 3,
+                      ],
+                      children: const [
+                        Icon(Icons.circle, color: Colors.grey),
+                        Icon(Icons.circle, color: Colors.red),
+                        Icon(Icons.circle, color: Colors.green),
+                        Icon(Icons.circle, color: Colors.blue),
+                      ],
+                    ),
+                    const SizedBox(height: 8.0),
+                    const Divider(thickness: 1.0),
+                    const SizedBox(height: 8.0),
+                    Text(
+                      "VendorColor (nRF54L15)",
+                      style: TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 8.0),
+
+                    ToggleButtons(
+                      onPressed: (int index) {
+                        // 0: none, 1: Red, 2: Green, 3: Blue
+                        int color = index;
+                        _vendorColorSet(
+                          unicastAddress: widget.meshNode.primaryUnicastAddress,
+                          color: color,
+                        );
+                      },
+                      isSelected: [
+                        vendorColorIndex == 0,
+                        vendorColorIndex == 1,
+                        vendorColorIndex == 2,
+                        vendorColorIndex == 3,
                       ],
                       children: const [
                         Icon(Icons.circle, color: Colors.grey),


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

### 概要 & 関連資料
<!-- issue番号を # の後に入れると PR merge 時に close される -->
- close #86 

### 変更内容
<!-- どのような変更をしたか -->
<!-- ex.) ユーザーがアプリを楽しく使えるようにタスク完了時にアニメーションをつけた -->


- [x] p2pでSwitchColorModelにメッセージを送信する機能の実装
  - [x] SwitchColorState, SwitchColorSet の作成
  - [x] platform channel
  - [x] UIボタン
 
### 影響範囲
<!-- どの画面に影響するか -->
<!-- ex.) タスク一覧画面 -->

- 接続画面の 接続済みノード に `VendorColor (nRF54L15)` を追加

### 備考
<!-- レビューに関してのコメントなど -->
<!-- ex.) ダークモードへの対応はできてないが、後で対応するのでスルーして下さい -->
<!-- ex.) 動作確認のためには、.envにENV=trueを追記して下さい -->

- 

### セルフチェック
- [ ] 環境変数などがPRに含まれていないか

<!-- I want to review in Japanese. -->
