### PR TITLE
provisioningの実装

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,10 +1,13 @@
 plugins {
     id("com.android.application")
+
     // START: FlutterFire Configuration
     id("com.google.gms.google-services")
     // END: FlutterFire Configuration
+
     id("kotlin-android")
-    // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
+
+    // Flutter Gradle PluginはAndroid・Kotlinプラグインの後に適用する
     id("dev.flutter.flutter-gradle-plugin")
 }
 
@@ -23,10 +26,8 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId = "jp.ac.saitama_u.mech.human.soccerAppFlutter"
-        // You can update the following values to match your application needs.
-        // For more information, see: https://flutter.dev/to/review-gradle-config.
+
         minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
@@ -35,8 +36,6 @@ android {
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.getByName("debug")
         }
     }
@@ -44,4 +43,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    implementation("no.nordicsemi.android:mesh:3.4.0")
 }

--- a/android/app/src/main/kotlin/jp/ac/saitama_u/mech/human/soccerAppFlutter/MainActivity.kt
+++ b/android/app/src/main/kotlin/jp/ac/saitama_u/mech/human/soccerAppFlutter/MainActivity.kt
@@ -3,83 +3,198 @@ package jp.ac.saitama_u.mech.human.soccerAppFlutter
 import android.Manifest
 import android.content.pm.PackageManager
 import android.os.Build
+import android.os.Bundle
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import jp.ac.saitama_u.mech.human.soccerAppFlutter.bluetooth.GeneralBleScanner
+import jp.ac.saitama_u.mech.human.soccerAppFlutter.bluetooth.ProvisioningService
 import jp.ac.saitama_u.mech.human.soccerAppFlutter.flutterchannels.FlutterChannelManager
+import jp.ac.saitama_u.mech.human.soccerAppFlutter.flutterchannels.ProvisioningEventStreamHandler
+import no.nordicsemi.android.mesh.MeshManagerApi
 
+/**
+ * Android Native層の初期化を担当するActivity。
+ *
+ * iOS版AppDelegate.swiftに近い役割を持ち、
+ * 各クラスを生成して依存関係を接続する。
+ */
 class MainActivity : FlutterActivity() {
 
     companion object {
-        private const val REQUEST_BLUETOOTH_PERMISSION = 1001
+        private const val REQUEST_BLUETOOTH_PERMISSIONS = 1001
     }
 
-    private lateinit var bleScanner: GeneralBleScanner
-    private lateinit var flutterChannelManager: FlutterChannelManager
+    /**
+     * Nordic Mesh SDKの中心となる管理クラス。
+     *
+     * アプリ内で同一インスタンスを共有する。
+     */
+    private lateinit var meshManagerApi: MeshManagerApi
 
-    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
-        super.configureFlutterEngine(flutterEngine)
+    /**
+     * 未Provisioningデバイスのスキャン担当。
+     */
+    private lateinit var bleScanner: GeneralBleScanner
+
+    /**
+     * Provisioning進捗をFlutterへ送る担当。
+     */
+    private lateinit var provisioningEventStreamHandler:
+        ProvisioningEventStreamHandler
+
+    /**
+     * Provisioning全体の進行管理担当。
+     */
+    private lateinit var provisioningService:
+        ProvisioningService
+
+    /**
+     * Flutterから届いた命令の振り分け担当。
+     */
+    private lateinit var flutterChannelManager:
+        FlutterChannelManager
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
 
         requestBluetoothPermissions()
+    }
 
-        bleScanner = GeneralBleScanner(this)
+    override fun configureFlutterEngine(
+        flutterEngine: FlutterEngine
+    ) {
+        super.configureFlutterEngine(flutterEngine)
 
-        flutterChannelManager = FlutterChannelManager(
-            messenger = flutterEngine.dartExecutor.binaryMessenger,
-            bleScanner = bleScanner
-        )
+        initializeNativeComponents()
+        setupFlutterChannels(flutterEngine)
+    }
+
+    /**
+     * Android Native層で使うクラスを生成する。
+     *
+     * 生成順:
+     * 1. MeshManagerApi
+     * 2. GeneralBleScanner
+     * 3. ProvisioningEventStreamHandler
+     * 4. ProvisioningService
+     */
+    private fun initializeNativeComponents() {
+        meshManagerApi =
+            MeshManagerApi(applicationContext)
+
+        bleScanner =
+            GeneralBleScanner(applicationContext)
+
+        provisioningEventStreamHandler =
+            ProvisioningEventStreamHandler()
+
+        provisioningService =
+            ProvisioningService(
+                context = applicationContext,
+                meshManagerApi = meshManagerApi,
+                bleScanner = bleScanner,
+                eventHandler =
+                    provisioningEventStreamHandler
+            )
+    }
+
+    /**
+     * FlutterとAndroid Native層のPlatform Channelを設定する。
+     */
+    private fun setupFlutterChannels(
+        flutterEngine: FlutterEngine
+    ) {
+        flutterChannelManager =
+            FlutterChannelManager(
+                messenger =
+                    flutterEngine
+                        .dartExecutor
+                        .binaryMessenger,
+                bleScanner = bleScanner,
+                provisioningService =
+                    provisioningService,
+                provisioningEventStreamHandler =
+                    provisioningEventStreamHandler
+            )
 
         flutterChannelManager.setupChannels()
     }
 
     /**
-     * Bluetooth権限を要求
+     * Androidバージョンに応じて、
+     * 必要なBluetooth実行時権限を要求する。
      */
     private fun requestBluetoothPermissions() {
+        val requiredPermissions =
+            mutableListOf<String>()
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-
-            val permissions = mutableListOf<String>()
-
-            if (ContextCompat.checkSelfPermission(
-                    this,
+        if (
+            Build.VERSION.SDK_INT >=
+            Build.VERSION_CODES.S
+        ) {
+            if (
+                !hasPermission(
                     Manifest.permission.BLUETOOTH_SCAN
-                ) != PackageManager.PERMISSION_GRANTED
+                )
             ) {
-                permissions.add(Manifest.permission.BLUETOOTH_SCAN)
-            }
-
-            if (ContextCompat.checkSelfPermission(
-                    this,
-                    Manifest.permission.BLUETOOTH_CONNECT
-                ) != PackageManager.PERMISSION_GRANTED
-            ) {
-                permissions.add(Manifest.permission.BLUETOOTH_CONNECT)
-            }
-
-            if (permissions.isNotEmpty()) {
-                ActivityCompat.requestPermissions(
-                    this,
-                    permissions.toTypedArray(),
-                    REQUEST_BLUETOOTH_PERMISSION
+                requiredPermissions.add(
+                    Manifest.permission.BLUETOOTH_SCAN
                 )
             }
 
-        } else {
-
-            if (ContextCompat.checkSelfPermission(
-                    this,
-                    Manifest.permission.ACCESS_FINE_LOCATION
-                ) != PackageManager.PERMISSION_GRANTED
+            if (
+                !hasPermission(
+                    Manifest.permission.BLUETOOTH_CONNECT
+                )
             ) {
-                ActivityCompat.requestPermissions(
-                    this,
-                    arrayOf(Manifest.permission.ACCESS_FINE_LOCATION),
-                    REQUEST_BLUETOOTH_PERMISSION
+                requiredPermissions.add(
+                    Manifest.permission.BLUETOOTH_CONNECT
+                )
+            }
+        } else {
+            if (
+                !hasPermission(
+                    Manifest.permission.ACCESS_FINE_LOCATION
+                )
+            ) {
+                requiredPermissions.add(
+                    Manifest.permission.ACCESS_FINE_LOCATION
                 )
             }
         }
+
+        if (requiredPermissions.isNotEmpty()) {
+            ActivityCompat.requestPermissions(
+                this,
+                requiredPermissions.toTypedArray(),
+                REQUEST_BLUETOOTH_PERMISSIONS
+            )
+        }
+    }
+
+    private fun hasPermission(
+        permission: String
+    ): Boolean {
+        return ContextCompat.checkSelfPermission(
+            this,
+            permission
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    /**
+     * Activity破棄時にスキャンとGATT接続を終了する。
+     */
+    override fun onDestroy() {
+        if (::bleScanner.isInitialized) {
+            bleScanner.stopScan()
+        }
+
+        if (::provisioningService.isInitialized) {
+            provisioningService.close()
+        }
+
+        super.onDestroy()
     }
 }

--- a/android/app/src/main/kotlin/jp/ac/saitama_u/mech/human/soccerAppFlutter/bluetooth/DiscoveredMeshDevice.kt
+++ b/android/app/src/main/kotlin/jp/ac/saitama_u/mech/human/soccerAppFlutter/bluetooth/DiscoveredMeshDevice.kt
@@ -1,0 +1,22 @@
+package jp.ac.saitama_u.mech.human.soccerAppFlutter.bluetooth
+
+import android.bluetooth.BluetoothDevice
+
+/**
+ * Android側で検出した、未ProvisioningのBluetooth Meshデバイス情報。
+ *
+ * Flutter側には表示に必要な情報だけを送るが、
+ * ProvisioningServiceではBluetoothDeviceやService Dataが必要になるため、
+ * Android Native側で保持しておく。
+ *
+ * @property bluetoothDevice BLE接続に使用するAndroidのBluetoothDevice
+ * @property serviceData Mesh Provisioning Service（0x1827）のService Data
+ * @property name デバイス名
+ * @property rssi 電波強度
+ */
+data class DiscoveredMeshDevice(
+    val bluetoothDevice: BluetoothDevice,
+    val serviceData: ByteArray,
+    val name: String,
+    val rssi: Int
+)

--- a/android/app/src/main/kotlin/jp/ac/saitama_u/mech/human/soccerAppFlutter/bluetooth/GeneralBleScanner.kt
+++ b/android/app/src/main/kotlin/jp/ac/saitama_u/mech/human/soccerAppFlutter/bluetooth/GeneralBleScanner.kt
@@ -8,73 +8,160 @@ import android.bluetooth.le.ScanResult
 import android.bluetooth.le.ScanSettings
 import android.content.Context
 import android.content.pm.PackageManager
+import android.os.Build
 import android.os.ParcelUuid
+import android.util.Log
 import androidx.core.content.ContextCompat
 import io.flutter.plugin.common.EventChannel
 import java.util.UUID
-import android.util.Log
+import java.util.concurrent.ConcurrentHashMap
 
-private const val TAG = "GeneralBleScanner"
-
+/**
+ * 未ProvisioningのBluetooth Meshデバイスを検出するスキャナ。
+ *
+ * Mesh Provisioning Service UUID（0x1827）を広告している
+ * BLEデバイスだけを対象にスキャンする。
+ *
+ * 検出結果はEventChannelを通してFlutterへ送信し、
+ * Provisioningに必要なNative情報はdiscoveredDevicesへ保存する。
+ */
 class GeneralBleScanner(
     private val context: Context
 ) : EventChannel.StreamHandler {
 
     companion object {
+        private const val TAG = "GeneralBleScanner"
+
+        /**
+         * Bluetooth Mesh Provisioning Service UUID。
+         *
+         * 0x1827は、まだMesh Networkへ登録されていない
+         *未Provisioningデバイスが広告するService UUID。
+         */
         private val MESH_PROVISIONING_SERVICE_UUID: UUID =
             UUID.fromString("00001827-0000-1000-8000-00805f9b34fb")
     }
 
-    // ### Android側のBluetoothの機能を取得する
+    /**
+     * Android端末のBluetooth機能を管理するクラス。
+     */
     private val bluetoothManager: BluetoothManager =
         context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
 
-    // ### BlutoothAdaptarの取得
-    // - Bluetoothの電源
-    // - Blurtooth機能
-    // - BluetoorhBleScannerの取得
+    /**
+     * Bluetoothアダプタ。
+     *
+     * Bluetoothの有効状態確認や、
+     * BluetoothLeScannerの取得に使用する。
+     */
     private val bluetoothAdapter
         get() = bluetoothManager.adapter
 
-    // ### BLEスキャンを行うクラス
+    /**
+     * BLEスキャンを実行するAndroid API。
+     */
     private val bluetoothLeScanner
         get() = bluetoothAdapter?.bluetoothLeScanner
 
-    //　### kotlin → flutter へデータを送る
+    /**
+     * KotlinからFlutterへイベントを送るための送信口。
+     */
     private var eventSink: EventChannel.EventSink? = null
+
+    /**
+     * 現在スキャン中かどうか。
+     */
     private var isScanning = false
 
+    /**
+     * 発見済みの未Provisioningデバイス一覧。
+     *
+     * キーにはBluetoothアドレスを使用する。
+     * Flutter側の既存仕様では、この値をuuidとして扱っている。
+     */
+    val discoveredDevices:
+        MutableMap<String, DiscoveredMeshDevice> = ConcurrentHashMap()
+
+    /**
+     * BLEスキャン結果を受け取るコールバック。
+     */
     private val scanCallback = object : ScanCallback() {
 
-        // ### 新しいデバイスが見つかるたびに呼ばれるメソッド
-        override fun onScanResult(callbackType: Int, result: ScanResult) {
-            Log.d(TAG, "新たなデバイスが発見されました")
+        /**
+         * BLEデバイスが検出されるたびに呼ばれる。
+         */
+        override fun onScanResult(
+            callbackType: Int,
+            result: ScanResult
+        ) {
+            val scanRecord = result.scanRecord ?: return
 
-            // 発見したデバイスを取得
-            val device = result.device
-            
-            // デバイス名を取得
-            // ※Android12以降では"BLUETOOTH_CONNECT"権限がないとdevice.nameを取得できないらしい
-            // 権限がないと"Unknown device"が返る
-            val deviceName = if (hasConnectPermission()) {
-                device.name ?: "Unknown device"
-            } else {
-                "Unknown device"
+            /**
+             * 0x1827のService Dataを取得する。
+             *
+             * Provisioning時にMesh Device UUIDを取得するために使用する。
+             */
+            val serviceData = scanRecord.getServiceData(
+                ParcelUuid(MESH_PROVISIONING_SERVICE_UUID)
+            ) ?: return
+
+            if (!hasConnectPermission()) {
+                eventSink?.error(
+                    "PERMISSION_DENIED",
+                    "BLUETOOTH_CONNECT permission is not granted",
+                    null
+                )
+                return
             }
-            
-            // flutterへ送るデータのmapデータ
+
+            val device = result.device
+            val deviceName = device.name ?: "Unknown device"
+
+            /**
+             * AndroidではBluetoothアドレスをデバイス識別用キーとして使う。
+             *
+             * Flutter側ではuuidという名前で扱っているが、
+             * Androidでは実際にはMACアドレスに相当する値。
+             */
+            val deviceId = device.address
+
+            /**
+             * Provisioningで必要になる情報をAndroid側へ保存する。
+             *
+             * 同じデバイスが再度検出された場合は、
+             * 最新のRSSIやService Dataで上書きされる。
+             */
+            discoveredDevices[deviceId] = DiscoveredMeshDevice(
+                bluetoothDevice = device,
+                serviceData = serviceData.copyOf(),
+                name = deviceName,
+                rssi = result.rssi
+            )
+
+            /**
+             * Flutterへ送信するデータ。
+             *
+             * Dart側のBleDevice.fromMap()が期待しているキー名に合わせる。
+             */
             val deviceData = mapOf(
                 "name" to deviceName,
-                "uuid" to device.address, //BluetoothデバイスのMACアドレスなので，正確にはUUIDではない
+                "uuid" to deviceId,
                 "rssi" to result.rssi
             )
-            
-            // flutterへデータを送信
+
             eventSink?.success(deviceData)
         }
 
+        /**
+         * BLEスキャンに失敗したときに呼ばれる。
+         */
         override fun onScanFailed(errorCode: Int) {
-            Log.d(TAG, "スキャンが失敗しました")
+            isScanning = false
+
+            Log.e(
+                TAG,
+                "BLE scan failed. errorCode=$errorCode"
+            )
 
             eventSink?.error(
                 "SCAN_FAILED",
@@ -84,28 +171,44 @@ class GeneralBleScanner(
         }
     }
 
-    // ### スキャンを開始する
+    /**
+     * 未ProvisioningのMeshデバイスのスキャンを開始する。
+     */
     fun startScan() {
-        Log.d(TAG, "スキャンを開始します")
+        if (isScanning) {
+            return
+        }
 
-        // 既にスキャン中なら何もしない
-        if (isScanning) return
-
-        // Bluetoothの権限チェック
         if (!hasScanPermission()) {
             eventSink?.error(
                 "PERMISSION_DENIED",
-                "BLUETOOTH_SCAN permission is not granted",
+                "Bluetooth scan permission is not granted",
                 null
             )
             return
         }
 
-        // ランタイム権限が許可されていることを確認 => 許可されていた
-        Log.d(TAG, "permission = ${hasScanPermission()}")
+        if (!hasConnectPermission()) {
+            eventSink?.error(
+                "PERMISSION_DENIED",
+                "Bluetooth connect permission is not granted",
+                null
+            )
+            return
+        }
 
-        // Bluetooth権限がONか確認する（OFFならエラーを返す）
-        if (bluetoothAdapter == null || bluetoothAdapter?.isEnabled != true) {
+        val adapter = bluetoothAdapter
+
+        if (adapter == null) {
+            eventSink?.error(
+                "BLUETOOTH_UNSUPPORTED",
+                "Bluetooth is not supported on this device",
+                null
+            )
+            return
+        }
+
+        if (!adapter.isEnabled) {
             eventSink?.error(
                 "BLUETOOTH_OFF",
                 "Bluetooth is not enabled",
@@ -113,89 +216,136 @@ class GeneralBleScanner(
             )
             return
         }
-        
-        // サービスUUIDによるフィルタ（1827というService UUIDを持つデバイスだけを見つける）
-        val filter = ScanFilter.Builder()
-            .setServiceUuid(ParcelUuid(MESH_PROVISIONING_SERVICE_UUID))
+
+        val scanner = bluetoothLeScanner
+
+        if (scanner == null) {
+            eventSink?.error(
+                "SCANNER_UNAVAILABLE",
+                "Bluetooth LE scanner is unavailable",
+                null
+            )
+            return
+        }
+
+        /**
+         * 新しいスキャンを始めるため、
+         * 前回保存した検出結果を削除する。
+         */
+        discoveredDevices.clear()
+
+        /**
+         * Mesh Provisioning Service（0x1827）を持つ
+         * デバイスだけに絞り込む。
+         */
+        val scanFilter = ScanFilter.Builder()
+            .setServiceUuid(
+                ParcelUuid(MESH_PROVISIONING_SERVICE_UUID)
+            )
             .build()
 
-        // 高速スキャンモード
-        val settings = ScanSettings.Builder()
-            .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
+        /**
+         * 検出速度を優先したスキャン設定。
+         *
+         * バッテリー消費は増えるため、
+         * 必要がなくなったらstopScan()を呼ぶ。
+         */
+        val scanSettings = ScanSettings.Builder()
+            .setScanMode(
+                ScanSettings.SCAN_MODE_LOW_LATENCY
+            )
             .build()
-        // 通常スキャンモード（デバッグ用）
-        // val settings = ScanSettings.Builder().build()
 
-        Log.d(TAG, "before startScan")
-
-        bluetoothLeScanner?.startScan(
-            // null, // フィルタをかけない（デバッグ用）
-            listOf(filter), // フィルタをかける
-            settings,
+        scanner.startScan(
+            listOf(scanFilter),
+            scanSettings,
             scanCallback
         )
-        Log.d(TAG, "after startScan")
 
         isScanning = true
+        Log.d(TAG, "Mesh Provisioning scan started")
     }
 
-
-    // ### スキャンを終了する
+    /**
+     * BLEスキャンを停止する。
+     */
     fun stopScan() {
-        if (!isScanning) return
+        if (!isScanning) {
+            return
+        }
 
-        if (!hasScanPermission()) return
+        if (!hasScanPermission()) {
+            isScanning = false
+            return
+        }
 
         bluetoothLeScanner?.stopScan(scanCallback)
         isScanning = false
 
-        Log.d(TAG, "スキャンを終了します")
+        Log.d(TAG, "Mesh Provisioning scan stopped")
     }
-    
-    
-    // ### Flutterとの通信路を確保する
-    // FlutterがreceiveBroadcastStream()を呼んだ瞬間に実行される
-    override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
-        Log.d(TAG,"start onListen")
 
+    /**
+     * 保存済みデバイスから、指定されたIDのデバイスを取得する。
+     *
+     * ProvisioningServiceから使用する。
+     */
+    fun getDiscoveredDevice(
+        deviceId: String
+    ): DiscoveredMeshDevice? {
+        return discoveredDevices[deviceId]
+    }
+
+    /**
+     * FlutterがEventChannelの購読を開始したときに呼ばれる。
+     */
+    override fun onListen(
+        arguments: Any?,
+        events: EventChannel.EventSink?
+    ) {
         eventSink = events
-
-
-        // ダミーデータ送信テスト（検証が終わったらコメントアウト）---------------------
-        // UIに表示されるかのテスト用
-        // val deviceData = mapOf(
-        //     "name" to "Dummy BLE Device",
-        //     "uuid" to "AA:BB:CC:DD:EE:FF",
-        //     "rssi" to -45
-        // )
-
-        // // flutterへデータを送信
-        // eventSink?.success(deviceData)
-        
-        // Log.d(TAG,"ダミーデータを送信します")
-        
-        // ダミーデータ送信テストここまで---------------------------------------------
     }
 
-
-    // ### eventSink破壊
-    // flutterが購読を解除すると，スキャン停止→eventSink破壊
+    /**
+     * FlutterがEventChannelの購読を解除したときに呼ばれる。
+     */
     override fun onCancel(arguments: Any?) {
         stopScan()
         eventSink = null
     }
 
+    /**
+     * BLEスキャンに必要な権限が許可されているか確認する。
+     */
     private fun hasScanPermission(): Boolean {
-        return ContextCompat.checkSelfPermission(
-            context,
-            Manifest.permission.BLUETOOTH_SCAN
-        ) == PackageManager.PERMISSION_GRANTED
+        return if (
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+        ) {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.BLUETOOTH_SCAN
+            ) == PackageManager.PERMISSION_GRANTED
+        } else {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.ACCESS_FINE_LOCATION
+            ) == PackageManager.PERMISSION_GRANTED
+        }
     }
 
+    /**
+     * Bluetoothデバイス情報の取得・接続に必要な権限を確認する。
+     */
     private fun hasConnectPermission(): Boolean {
-        return ContextCompat.checkSelfPermission(
-            context,
-            Manifest.permission.BLUETOOTH_CONNECT
-        ) == PackageManager.PERMISSION_GRANTED
+        return if (
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+        ) {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.BLUETOOTH_CONNECT
+            ) == PackageManager.PERMISSION_GRANTED
+        } else {
+            true
+        }
     }
 }

--- a/android/app/src/main/kotlin/jp/ac/saitama_u/mech/human/soccerAppFlutter/bluetooth/ProvisioningConnection.kt
+++ b/android/app/src/main/kotlin/jp/ac/saitama_u/mech/human/soccerAppFlutter/bluetooth/ProvisioningConnection.kt
@@ -1,0 +1,781 @@
+package jp.ac.saitama_u.mech.human.soccerAppFlutter.bluetooth
+
+import android.Manifest
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCallback
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
+import android.bluetooth.BluetoothProfile
+import android.bluetooth.BluetoothStatusCodes
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
+import androidx.core.content.ContextCompat
+import java.util.ArrayDeque
+import java.util.UUID
+
+/**
+ * 未ProvisioningのBluetooth Meshデバイスとの
+ * BLE GATT通信を管理するクラス。
+ *
+ * 主な役割:
+ * ・対象デバイスへの接続
+ * ・Mesh Provisioning Serviceの探索
+ * ・Provisioning Data Out通知の有効化
+ * ・Provisioning Data InへのPDU書き込み
+ * ・受信データや接続状態をProvisioningServiceへ通知
+ */
+class ProvisioningConnection(
+    private val context: Context,
+    private val listener: Listener
+) {
+
+    interface Listener {
+
+        fun onConnecting()
+
+        fun onConnected()
+
+        fun onDiscoveringServices()
+
+        /**
+         * Provisioning用Characteristicの準備完了時に呼ばれる。
+         *
+         * @param mtu Androidから通知されたATT MTU
+         */
+        fun onReady(mtu: Int)
+
+        fun onNotificationReceived(data: ByteArray)
+
+        /**
+         * 1つのGATT SARパケットの書き込みが完了するたびに呼ばれる。
+         */
+        fun onWriteCompleted(data: ByteArray)
+
+        fun onDisconnected(message: String?)
+
+        fun onError(message: String)
+    }
+
+    companion object {
+        private const val TAG = "ProvisioningConnection"
+
+        /** Mesh Provisioning Service: 0x1827 */
+        private val MESH_PROVISIONING_SERVICE_UUID: UUID =
+            UUID.fromString(
+                "00001827-0000-1000-8000-00805f9b34fb"
+            )
+
+        /** Provisioning Data In: 0x2ADB */
+        private val PROVISIONING_DATA_IN_UUID: UUID =
+            UUID.fromString(
+                "00002adb-0000-1000-8000-00805f9b34fb"
+            )
+
+        /** Provisioning Data Out: 0x2ADC */
+        private val PROVISIONING_DATA_OUT_UUID: UUID =
+            UUID.fromString(
+                "00002adc-0000-1000-8000-00805f9b34fb"
+            )
+
+        /** Client Characteristic Configuration Descriptor */
+        private val CCCD_UUID: UUID =
+            UUID.fromString(
+                "00002902-0000-1000-8000-00805f9b34fb"
+            )
+
+        private const val REQUESTED_MTU = 247
+        private const val DEFAULT_ATT_MTU = 23
+
+        /**
+         * ATT Write Request/Commandのヘッダー分。
+         *
+         * Characteristicへ書き込めるデータサイズは、
+         * 基本的にATT MTU - 3。
+         */
+        private const val ATT_WRITE_HEADER_SIZE = 3
+
+        /** ATT MTU 23の場合に書き込める標準ペイロードサイズ */
+        private const val DEFAULT_GATT_PAYLOAD_SIZE = 20
+    }
+
+    private var bluetoothGatt: BluetoothGatt? = null
+
+    private var provisioningDataIn:
+        BluetoothGattCharacteristic? = null
+
+    private var provisioningDataOut:
+        BluetoothGattCharacteristic? = null
+
+    /**
+     * Androidから通知されたATT MTU。
+     *
+     * 例:
+     * ATT MTU 33なら、Characteristicへ書き込めるサイズは30バイト。
+     */
+    private var currentAttMtu = DEFAULT_ATT_MTU
+
+    /**
+     * Nordic Mesh SDKから渡されたデータを、
+     * GATTへ書き込めるサイズに区切って保持するキュー。
+     */
+    private val writeQueue = ArrayDeque<ByteArray>()
+
+    /**
+     * 現在Characteristicへ書き込み中のデータ。
+     */
+    private var currentWriteData: ByteArray? = null
+
+    private var isWriting = false
+    private var isReady = false
+    private var isDisconnectRequested = false
+
+    private val gattCallback = object : BluetoothGattCallback() {
+
+        override fun onConnectionStateChange(
+            gatt: BluetoothGatt,
+            status: Int,
+            newState: Int
+        ) {
+            Log.d(
+                TAG,
+                "onConnectionStateChange: " +
+                    "status=$status, newState=$newState"
+            )
+
+            /*
+             * status=0以外の場合はGATTレベルのエラー。
+             *
+             * status=19は接続先からの切断として返されることがある。
+             */
+            if (status != BluetoothGatt.GATT_SUCCESS) {
+                val message =
+                    "GATT connection failed. status=$status"
+
+                Log.e(TAG, message)
+
+                listener.onError(message)
+                closeGatt(gatt)
+                return
+            }
+
+            when (newState) {
+                BluetoothProfile.STATE_CONNECTED -> {
+                    Log.d(TAG, "Provisioning device connected")
+
+                    listener.onConnected()
+
+                    val mtuRequestStarted =
+                        gatt.requestMtu(REQUESTED_MTU)
+
+                    if (!mtuRequestStarted) {
+                        currentAttMtu = DEFAULT_ATT_MTU
+                        startServiceDiscovery(gatt)
+                    }
+                }
+
+                BluetoothProfile.STATE_DISCONNECTED -> {
+                    Log.d(TAG, "Provisioning device disconnected")
+
+                    val manuallyDisconnected =
+                        isDisconnectRequested
+
+                    closeGatt(gatt)
+
+                    listener.onDisconnected(
+                        if (manuallyDisconnected) {
+                            null
+                        } else {
+                            "Provisioning device disconnected."
+                        }
+                    )
+                }
+            }
+        }
+
+        override fun onMtuChanged(
+            gatt: BluetoothGatt,
+            mtu: Int,
+            status: Int
+        ) {
+            currentAttMtu =
+                if (status == BluetoothGatt.GATT_SUCCESS) {
+                    mtu
+                } else {
+                    DEFAULT_ATT_MTU
+                }
+
+            Log.d(
+                TAG,
+                "ATT MTU=$currentAttMtu, " +
+                    "GATT payload=${getGattPayloadSize()}"
+            )
+
+            startServiceDiscovery(gatt)
+        }
+
+        override fun onServicesDiscovered(
+            gatt: BluetoothGatt,
+            status: Int
+        ) {
+            Log.d(
+                TAG,
+                "onServicesDiscovered: status=$status"
+            )
+
+            if (status != BluetoothGatt.GATT_SUCCESS) {
+                reportError(
+                    "Service discovery failed. status=$status"
+                )
+                return
+            }
+
+            val provisioningService =
+                gatt.getService(
+                    MESH_PROVISIONING_SERVICE_UUID
+                )
+
+            if (provisioningService == null) {
+                reportError(
+                    "Mesh Provisioning Service (0x1827) " +
+                        "was not found."
+                )
+                return
+            }
+
+            Log.d(TAG, "Mesh Provisioning Service found")
+
+            provisioningDataIn =
+                provisioningService.getCharacteristic(
+                    PROVISIONING_DATA_IN_UUID
+                )
+
+            provisioningDataOut =
+                provisioningService.getCharacteristic(
+                    PROVISIONING_DATA_OUT_UUID
+                )
+
+            if (provisioningDataIn == null) {
+                reportError(
+                    "Provisioning Data In characteristic " +
+                        "(0x2ADB) was not found."
+                )
+                return
+            }
+
+            val dataOut = provisioningDataOut
+
+            if (dataOut == null) {
+                reportError(
+                    "Provisioning Data Out characteristic " +
+                        "(0x2ADC) was not found."
+                )
+                return
+            }
+
+            Log.d(
+                TAG,
+                "Provisioning Data In and Data Out found"
+            )
+
+            enableProvisioningNotifications(
+                gatt = gatt,
+                characteristic = dataOut
+            )
+        }
+
+        override fun onDescriptorWrite(
+            gatt: BluetoothGatt,
+            descriptor: BluetoothGattDescriptor,
+            status: Int
+        ) {
+            if (descriptor.uuid != CCCD_UUID) {
+                return
+            }
+
+            if (status != BluetoothGatt.GATT_SUCCESS) {
+                reportError(
+                    "Failed to enable provisioning notifications. " +
+                        "status=$status"
+                )
+                return
+            }
+
+            isReady = true
+
+            Log.d(
+                TAG,
+                "Provisioning notification enabled"
+            )
+
+            listener.onReady(currentAttMtu)
+        }
+
+        /**
+         * Android 13以上で利用される通知Callback。
+         */
+        override fun onCharacteristicChanged(
+            gatt: BluetoothGatt,
+            characteristic: BluetoothGattCharacteristic,
+            value: ByteArray
+        ) {
+            handleCharacteristicNotification(
+                characteristic = characteristic,
+                value = value
+            )
+        }
+
+        /**
+         * Android 12以下で利用される通知Callback。
+         */
+        @Deprecated("Deprecated in Android API 33")
+        override fun onCharacteristicChanged(
+            gatt: BluetoothGatt,
+            characteristic: BluetoothGattCharacteristic
+        ) {
+            val value = characteristic.value ?: return
+
+            handleCharacteristicNotification(
+                characteristic = characteristic,
+                value = value
+            )
+        }
+
+        override fun onCharacteristicWrite(
+            gatt: BluetoothGatt,
+            characteristic: BluetoothGattCharacteristic,
+            status: Int
+        ) {
+            if (
+                characteristic.uuid !=
+                PROVISIONING_DATA_IN_UUID
+            ) {
+                return
+            }
+
+            val writtenData = currentWriteData
+
+            currentWriteData = null
+            isWriting = false
+
+            Log.d(
+                TAG,
+                "Provisioning chunk written: " +
+                    "status=$status, " +
+                    "size=${writtenData?.size ?: 0}"
+            )
+
+            if (status != BluetoothGatt.GATT_SUCCESS) {
+                clearWriteQueue()
+
+                reportError(
+                    "Failed to write provisioning PDU. " +
+                        "status=$status"
+                )
+                return
+            }
+
+            /*
+             * Nordic Mesh SDKへ、
+             * 実際に書き込んだGATT SARパケットを返す。
+             *
+             * SDK側は複数のパケットを再構成し、
+             * 最後のパケットまで完了すると次の状態へ進む。
+             */
+            if (writtenData != null) {
+                listener.onWriteCompleted(
+                    writtenData.copyOf()
+                )
+            }
+
+            writeNextPacket()
+        }
+    }
+
+    /**
+     * 未Provisioningデバイスへの接続を開始する。
+     */
+    fun connect(device: BluetoothDevice) {
+        if (!hasConnectPermission()) {
+            listener.onError(
+                "BLUETOOTH_CONNECT permission is not granted."
+            )
+            return
+        }
+
+        close()
+
+        isDisconnectRequested = false
+        isReady = false
+        currentAttMtu = DEFAULT_ATT_MTU
+
+        listener.onConnecting()
+
+        Log.d(
+            TAG,
+            "Connecting to provisioning device"
+        )
+
+        bluetoothGatt = device.connectGatt(
+            context,
+            false,
+            gattCallback,
+            BluetoothDevice.TRANSPORT_LE
+        )
+    }
+
+    /**
+     * Nordic Mesh SDKが生成したProvisioning用データを、
+     * GATTへ順番に書き込む。
+     *
+     * Nordic Mesh SDK側ですでにGATT SARヘッダーが付加され、
+     * 1つのByteArrayへ連結されている。
+     *
+     * そのため、ここではSARを新しく付け直さず、
+     * SDKのgetMtu()と同じサイズごとに切り分ける。
+     */
+    fun writeProvisioningPdu(data: ByteArray) {
+        if (!hasConnectPermission()) {
+            listener.onError(
+                "BLUETOOTH_CONNECT permission is not granted."
+            )
+            return
+        }
+
+        if (!isReady) {
+            listener.onError(
+                "Provisioning GATT connection is not ready."
+            )
+            return
+        }
+
+        if (
+            bluetoothGatt == null ||
+            provisioningDataIn == null
+        ) {
+            listener.onError(
+                "Provisioning Data In characteristic " +
+                    "is unavailable."
+            )
+            return
+        }
+
+        val packetSize = getGattPayloadSize()
+
+        /*
+         * MeshManagerApi.applySegmentation()が作成した
+         * 連結済みGATT SARパケットを、packetSizeごとに分ける。
+         *
+         * 例:
+         * ATT MTU = 33
+         * packetSize = 30
+         *
+         * 69バイトのデータなら:
+         * 30 + 30 + 9
+         */
+        var offset = 0
+        var addedPacketCount = 0
+
+        while (offset < data.size) {
+            val end =
+                minOf(
+                    offset + packetSize,
+                    data.size
+                )
+
+            val packet =
+                data.copyOfRange(offset, end)
+
+            writeQueue.addLast(packet)
+
+            offset = end
+            addedPacketCount++
+        }
+
+        Log.d(
+            TAG,
+            "Provisioning data queued: " +
+                "total=${data.size}, " +
+                "packets=$addedPacketCount, " +
+                "packetSize=$packetSize"
+        )
+
+        writeNextPacket()
+    }
+
+    /**
+     * 書き込みキューの先頭データを1つだけ送信する。
+     *
+     * 次のデータはonCharacteristicWrite()後に送信するため、
+     * 複数のGATT書き込みが同時に走らない。
+     */
+    private fun writeNextPacket() {
+        if (isWriting) {
+            return
+        }
+
+        val packet = writeQueue.pollFirst()
+            ?: return
+
+        val gatt = bluetoothGatt
+        val characteristic = provisioningDataIn
+
+        if (gatt == null || characteristic == null) {
+            clearWriteQueue()
+
+            listener.onError(
+                "Provisioning GATT connection is unavailable."
+            )
+            return
+        }
+
+        isWriting = true
+        currentWriteData = packet
+
+        Log.d(
+            TAG,
+            "Writing provisioning packet: " +
+                "${packet.size} bytes"
+        )
+
+        val writeStarted =
+            if (
+                Build.VERSION.SDK_INT >=
+                Build.VERSION_CODES.TIRAMISU
+            ) {
+                val result =
+                    gatt.writeCharacteristic(
+                        characteristic,
+                        packet,
+                        BluetoothGattCharacteristic
+                            .WRITE_TYPE_NO_RESPONSE
+                    )
+
+                result == BluetoothStatusCodes.SUCCESS
+            } else {
+                @Suppress("DEPRECATION")
+                characteristic.writeType =
+                    BluetoothGattCharacteristic
+                        .WRITE_TYPE_NO_RESPONSE
+
+                @Suppress("DEPRECATION")
+                characteristic.value = packet
+
+                @Suppress("DEPRECATION")
+                gatt.writeCharacteristic(characteristic)
+            }
+
+        if (!writeStarted) {
+            currentWriteData = null
+            isWriting = false
+            clearWriteQueue()
+
+            listener.onError(
+                "Failed to start writing provisioning PDU."
+            )
+        }
+    }
+
+    /**
+     * 接続を切断する。
+     */
+    fun disconnect() {
+        isDisconnectRequested = true
+        isReady = false
+
+        clearWriteQueue()
+
+        if (!hasConnectPermission()) {
+            close()
+            return
+        }
+
+        bluetoothGatt?.disconnect()
+    }
+
+    /**
+     * GATT接続を完全に破棄する。
+     */
+    fun close() {
+        isDisconnectRequested = true
+        isReady = false
+
+        clearWriteQueue()
+
+        val gatt = bluetoothGatt
+
+        if (
+            gatt != null &&
+            hasConnectPermission()
+        ) {
+            /*
+             * 新しい接続を始める前の破棄処理なので、
+             * 接続解除を要求してからcloseする。
+             */
+            gatt.disconnect()
+            gatt.close()
+        }
+
+        bluetoothGatt = null
+        provisioningDataIn = null
+        provisioningDataOut = null
+        currentAttMtu = DEFAULT_ATT_MTU
+    }
+
+    /**
+     * Androidから通知されたATT MTUを返す。
+     */
+    fun getAttMtu(): Int {
+        return currentAttMtu
+    }
+
+    /**
+     * Characteristicへ1回で書き込めるデータサイズを返す。
+     */
+    fun getGattPayloadSize(): Int {
+        return (
+            currentAttMtu - ATT_WRITE_HEADER_SIZE
+        ).coerceAtLeast(
+            DEFAULT_GATT_PAYLOAD_SIZE
+        )
+    }
+
+    private fun startServiceDiscovery(
+        gatt: BluetoothGatt
+    ) {
+        listener.onDiscoveringServices()
+
+        Log.d(TAG, "Starting service discovery")
+
+        if (!gatt.discoverServices()) {
+            reportError(
+                "Failed to start GATT service discovery."
+            )
+        }
+    }
+
+    private fun enableProvisioningNotifications(
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic
+    ) {
+        val notificationEnabled =
+            gatt.setCharacteristicNotification(
+                characteristic,
+                true
+            )
+
+        if (!notificationEnabled) {
+            reportError(
+                "Failed to enable local provisioning notifications."
+            )
+            return
+        }
+
+        val descriptor =
+            characteristic.getDescriptor(CCCD_UUID)
+
+        if (descriptor == null) {
+            reportError(
+                "Provisioning notification descriptor " +
+                    "was not found."
+            )
+            return
+        }
+
+        val writeStarted =
+            if (
+                Build.VERSION.SDK_INT >=
+                Build.VERSION_CODES.TIRAMISU
+            ) {
+                val result =
+                    gatt.writeDescriptor(
+                        descriptor,
+                        BluetoothGattDescriptor
+                            .ENABLE_NOTIFICATION_VALUE
+                    )
+
+                result == BluetoothStatusCodes.SUCCESS
+            } else {
+                @Suppress("DEPRECATION")
+                descriptor.value =
+                    BluetoothGattDescriptor
+                        .ENABLE_NOTIFICATION_VALUE
+
+                @Suppress("DEPRECATION")
+                gatt.writeDescriptor(descriptor)
+            }
+
+        if (!writeStarted) {
+            reportError(
+                "Failed to start writing " +
+                    "notification descriptor."
+            )
+        }
+    }
+
+    private fun handleCharacteristicNotification(
+        characteristic: BluetoothGattCharacteristic,
+        value: ByteArray
+    ) {
+        if (
+            characteristic.uuid !=
+            PROVISIONING_DATA_OUT_UUID
+        ) {
+            return
+        }
+
+        Log.d(
+            TAG,
+            "Provisioning notification received: " +
+                "${value.size} bytes"
+        )
+
+        listener.onNotificationReceived(
+            value.copyOf()
+        )
+    }
+
+    private fun clearWriteQueue() {
+        writeQueue.clear()
+        currentWriteData = null
+        isWriting = false
+    }
+
+    private fun reportError(message: String) {
+        Log.e(TAG, message)
+        listener.onError(message)
+    }
+
+    private fun closeGatt(gatt: BluetoothGatt) {
+        if (hasConnectPermission()) {
+            gatt.close()
+        }
+
+        if (bluetoothGatt === gatt) {
+            bluetoothGatt = null
+        }
+
+        provisioningDataIn = null
+        provisioningDataOut = null
+        currentAttMtu = DEFAULT_ATT_MTU
+        isReady = false
+
+        clearWriteQueue()
+    }
+
+    private fun hasConnectPermission(): Boolean {
+        return if (
+            Build.VERSION.SDK_INT >=
+            Build.VERSION_CODES.S
+        ) {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.BLUETOOTH_CONNECT
+            ) == PackageManager.PERMISSION_GRANTED
+        } else {
+            true
+        }
+    }
+}

--- a/android/app/src/main/kotlin/jp/ac/saitama_u/mech/human/soccerAppFlutter/bluetooth/ProvisioningService.kt
+++ b/android/app/src/main/kotlin/jp/ac/saitama_u/mech/human/soccerAppFlutter/bluetooth/ProvisioningService.kt
@@ -1,0 +1,626 @@
+package jp.ac.saitama_u.mech.human.soccerAppFlutter.bluetooth
+
+import android.content.Context
+import android.util.Log
+import io.flutter.plugin.common.MethodChannel
+import jp.ac.saitama_u.mech.human.soccerAppFlutter.flutterchannels.ProvisioningEventStreamHandler
+import no.nordicsemi.android.mesh.MeshManagerApi
+import no.nordicsemi.android.mesh.MeshManagerCallbacks
+import no.nordicsemi.android.mesh.MeshNetwork
+import no.nordicsemi.android.mesh.MeshProvisioningStatusCallbacks
+import no.nordicsemi.android.mesh.MeshStatusCallbacks
+import no.nordicsemi.android.mesh.provisionerstates.ProvisioningState
+import no.nordicsemi.android.mesh.provisionerstates.UnprovisionedMeshNode
+import no.nordicsemi.android.mesh.transport.ControlMessage
+import no.nordicsemi.android.mesh.transport.MeshMessage
+import no.nordicsemi.android.mesh.transport.ProvisionedMeshNode
+import java.util.UUID
+
+/**
+ * 未ProvisioningのBluetooth Meshデバイスを
+ * Mesh Networkへ登録する処理を管理するクラス。
+ *
+ * 役割:
+ * ・FlutterからProvisioning開始命令を受け取る
+ * ・スキャン済みデバイスを取得する
+ * ・ProvisioningConnectionへBLE接続を依頼する
+ * ・Nordic Mesh SDKへ受信データを渡す
+ * ・SDKが生成したPDUをProvisioningConnectionへ渡す
+ * ・Provisioning進捗をFlutterへ通知する
+ */
+class ProvisioningService(
+    context: Context,
+    private val meshManagerApi: MeshManagerApi,
+    private val bleScanner: GeneralBleScanner,
+    private val eventHandler: ProvisioningEventStreamHandler
+) : MeshManagerCallbacks,
+    MeshProvisioningStatusCallbacks,
+    MeshStatusCallbacks,
+    ProvisioningConnection.Listener {
+
+    companion object {
+        private const val TAG = "ProvisioningService"
+
+        /**
+         * 対象デバイスを識別状態にする時間。
+         * iOS版のattentionTimer = 5と対応する。
+         */
+        private const val ATTENTION_TIMER_SECONDS = 5
+
+        /**
+         * MTUネゴシエーション前の初期値。
+         */
+        private const val DEFAULT_MTU = 23
+    }
+
+    /**
+     * Provisioning対象とのGATT通信を担当する。
+     */
+    private val provisioningConnection =
+        ProvisioningConnection(
+            context = context.applicationContext,
+            listener = this
+        )
+
+    /**
+     * 現在読み込まれているMesh Network。
+     */
+    private var meshNetwork: MeshNetwork? = null
+
+    /**
+     * 現在Provisioning対象になっているデバイス。
+     */
+    private var targetDevice: DiscoveredMeshDevice? = null
+
+    /**
+     * Mesh Provisioning Service Dataから取得した
+     * Bluetooth Mesh固有のDevice UUID。
+     */
+    private var targetMeshDeviceUuid: UUID? = null
+
+    /**
+     * 現在のBLE MTU。
+     */
+    private var currentMtu = DEFAULT_MTU
+
+    /**
+     * Provisioning処理が正常終了したか。
+     *
+     * Provisioning完了後の意図的な切断を
+     * エラーとしてFlutterへ通知しないために使用する。
+     */
+    private var provisioningCompleted = false
+
+    init {
+        meshManagerApi.setMeshManagerCallbacks(this)
+        meshManagerApi.setProvisioningStatusCallbacks(this)
+        meshManagerApi.setMeshStatusCallbacks(this)
+
+        meshManagerApi.loadMeshNetwork()
+    }
+
+    /**
+     * Flutterから呼び出されるProvisioning開始処理。
+     *
+     * @param deviceId Flutter側ではuuidと呼んでいるが、
+     * Android側ではスキャン時のBluetoothアドレス。
+     */
+    fun startProvisioningProcess(
+        deviceId: String,
+        result: MethodChannel.Result
+    ) {
+        cleanupProvisioningState(closeConnection = true)
+
+        val discoveredDevice =
+            bleScanner.getDiscoveredDevice(deviceId)
+
+        if (discoveredDevice == null) {
+            respond(
+                result = result,
+                isSuccess = false,
+                message = "Device not found in scan results."
+            )
+            return
+        }
+
+        if (meshNetwork == null) {
+            respond(
+                result = result,
+                isSuccess = false,
+                message = "Mesh Network is not ready."
+            )
+            return
+        }
+
+        val meshDeviceUuid = try {
+            /*
+             * 0x1827のService Dataから、
+             * Bluetooth Mesh Device UUIDを取り出す。
+             */
+            meshManagerApi.getDeviceUuid(
+                discoveredDevice.serviceData
+            )
+        } catch (exception: IllegalArgumentException) {
+            Log.e(
+                TAG,
+                "Invalid Mesh Provisioning Service Data",
+                exception
+            )
+
+            respond(
+                result = result,
+                isSuccess = false,
+                message = exception.message
+                    ?: "Failed to obtain Mesh Device UUID."
+            )
+            return
+        }
+
+        targetDevice = discoveredDevice
+        targetMeshDeviceUuid = meshDeviceUuid
+        provisioningCompleted = false
+
+        /*
+         * Provisioning中はBLEスキャンを停止する。
+         */
+        bleScanner.stopScan()
+
+        /*
+         * 未ProvisioningデバイスへGATT接続する。
+         */
+        provisioningConnection.connect(
+            discoveredDevice.bluetoothDevice
+        )
+
+        respond(
+            result = result,
+            isSuccess = true,
+            message = "Provisioning process initiated."
+        )
+    }
+
+    /**
+     * Activity破棄時などに使用する。
+     */
+    fun close() {
+        cleanupProvisioningState(closeConnection = true)
+    }
+
+    // -------------------------------------------------------------------------
+    // ProvisioningConnection.Listener
+    // -------------------------------------------------------------------------
+
+    override fun onConnecting() {
+        eventHandler.sendEvent(
+            status = ProvisioningEventStreamHandler.STATUS_CONNECTING,
+            data = mapOf(
+                "message" to
+                    "Connecting to ${targetDevice?.name ?: "device"}..."
+            )
+        )
+    }
+
+    override fun onConnected() {
+        eventHandler.sendEvent(
+            status = ProvisioningEventStreamHandler.STATUS_DISCOVERING,
+            data = mapOf(
+                "message" to "Connected. Preparing service discovery..."
+            )
+        )
+    }
+
+    override fun onDiscoveringServices() {
+        eventHandler.sendEvent(
+            status = ProvisioningEventStreamHandler.STATUS_DISCOVERING,
+            data = mapOf(
+                "message" to "Discovering provisioning services..."
+            )
+        )
+    }
+
+    /**
+     * 0x1827 Service、Data In、Data Out、
+     * Notificationの準備が完了したときに呼ばれる。
+     */
+    override fun onReady(mtu: Int) {
+        currentMtu =
+        (mtu - 3).coerceAtLeast(20)
+
+        val deviceUuid = targetMeshDeviceUuid
+
+        if (deviceUuid == null) {
+        handleConnectionError(
+            "Mesh Device UUID is not available."
+        )
+        return
+        }
+
+        eventHandler.sendEvent(
+            status =
+                ProvisioningEventStreamHandler.STATUS_IDENTIFYING,
+            data = mapOf(
+                "message" to "Identifying device..."
+            )
+        
+        )
+
+        try {
+            meshManagerApi.identifyNode(
+            deviceUuid,
+            ATTENTION_TIMER_SECONDS
+            )
+        
+        } catch (exception: IllegalArgumentException) {
+            handleConnectionError(
+            "Failed to identify node: " +
+                (exception.message ?: "Unknown error")
+            )       
+        }  
+    }
+
+    /**
+     * Provisioning Data Out Characteristicから受信した通知。
+     */
+    override fun onNotificationReceived(data: ByteArray) {
+        try {
+            meshManagerApi.handleNotifications(
+                currentMtu,
+                data
+            )
+        } catch (exception: RuntimeException) {
+            Log.e(
+                TAG,
+                "Failed to process provisioning notification",
+                exception
+            )
+
+            handleConnectionError(
+                "Failed to process provisioning notification: " +
+                    (exception.message ?: "Unknown error")
+            )
+        }
+    }
+
+    /**
+     * Provisioning Data In Characteristicへの
+     * PDU書き込みが完了したときに呼ばれる。
+     */
+    override fun onWriteCompleted(data: ByteArray) {
+        try {
+            meshManagerApi.handleWriteCallbacks(
+                currentMtu,
+                data
+            )
+        } catch (exception: RuntimeException) {
+            Log.e(
+                TAG,
+                "Failed to process provisioning write callback",
+                exception
+            )
+
+            handleConnectionError(
+                "Failed to process provisioning write: " +
+                    (exception.message ?: "Unknown error")
+            )
+        }
+    }
+
+    override fun onDisconnected(message: String?) {
+        /*
+         * Provisioning完了後または明示的close()による切断は
+         * エラーとして扱わない。
+         */
+        if (!provisioningCompleted && message != null) {
+            eventHandler.sendError(message)
+        }
+
+        cleanupProvisioningState(
+            closeConnection = false
+        )
+    }
+
+    override fun onError(message: String) {
+        handleConnectionError(message)
+    }
+
+    // -------------------------------------------------------------------------
+    // MeshManagerCallbacks
+    // -------------------------------------------------------------------------
+
+    override fun onNetworkLoaded(meshNetwork: MeshNetwork) {
+        this.meshNetwork = meshNetwork
+
+        Log.d(
+            TAG,
+            "Mesh Network loaded: ${meshNetwork.meshName}"
+        )
+    }
+
+    override fun onNetworkUpdated(meshNetwork: MeshNetwork) {
+        this.meshNetwork = meshNetwork
+
+        Log.d(TAG, "Mesh Network updated")
+    }
+
+    override fun onNetworkLoadFailed(error: String) {
+        Log.w(
+            TAG,
+            "Mesh Network load failed. Creating a new network: $error"
+        )
+
+        /*
+         * 保存済みネットワークがない場合、
+         * 新しいMesh Networkを作成する。
+         *
+         * createMeshNetwork()の結果は
+         * onNetworkLoaded()へ返される。
+         */
+        try {
+            meshManagerApi.createMeshNetwork()
+        } catch (exception: RuntimeException) {
+            Log.e(
+                TAG,
+                "Failed to create Mesh Network",
+                exception
+            )
+
+            eventHandler.sendError(
+                "Failed to create Mesh Network: " +
+                    (exception.message ?: error)
+            )
+        }
+    }
+
+    override fun onNetworkImported(meshNetwork: MeshNetwork) {
+        this.meshNetwork = meshNetwork
+
+        Log.d(TAG, "Mesh Network imported")
+    }
+
+    override fun onNetworkImportFailed(error: String) {
+        Log.e(
+            TAG,
+            "Mesh Network import failed: $error"
+        )
+
+        eventHandler.sendError(
+            "Failed to import Mesh Network: $error"
+        )
+    }
+
+    /**
+     * Nordic Mesh SDKがProvisioning用PDUを生成したときに呼ばれる。
+     */
+    override fun sendProvisioningPdu(
+        meshNode: UnprovisionedMeshNode,
+        pdu: ByteArray
+    ) {
+        Log.d(
+            TAG,
+            "Provisioning PDU created: ${pdu.size} bytes"
+        )
+
+        provisioningConnection.writeProvisioningPdu(pdu)
+    }
+
+    /**
+     * 通常のMesh通信PDU生成時に呼ばれる。
+     *
+     * 現在はProxy接続未実装のため使用しない。
+     */
+    override fun onMeshPduCreated(pdu: ByteArray) {
+        Log.d(
+            TAG,
+            "Mesh PDU created: ${pdu.size} bytes"
+        )
+    }
+
+    override fun getMtu(): Int {
+        return currentMtu
+    }
+
+    // -------------------------------------------------------------------------
+    // MeshProvisioningStatusCallbacks
+    // -------------------------------------------------------------------------
+
+    override fun onProvisioningStateChanged(
+        meshNode: UnprovisionedMeshNode,
+        state: ProvisioningState.States,
+        data: ByteArray?
+    ) {
+        Log.d(
+            TAG,
+            "Provisioning state changed: $state"
+        )
+
+        val flutterStatus = when (state) {
+            ProvisioningState.States.PROVISIONING_INVITE,
+            ProvisioningState.States.PROVISIONING_CAPABILITIES -> {
+                ProvisioningEventStreamHandler.STATUS_IDENTIFYING
+            }
+
+            else -> {
+                ProvisioningEventStreamHandler.STATUS_PROVISIONING
+            }
+        }
+
+        eventHandler.sendEvent(
+            status = flutterStatus,
+            data = mapOf(
+                "message" to state.name
+            )
+        )
+
+        /*
+         * デバイスのCapabilitiesを受信したら、
+         * No OOB方式でProvisioning本体を開始する。
+         */
+        if (
+            state ==
+            ProvisioningState.States.PROVISIONING_CAPABILITIES
+        ) {
+            try {
+                meshManagerApi.startProvisioning(meshNode)
+            } catch (exception: IllegalArgumentException) {
+                Log.e(
+                    TAG,
+                    "Failed to start provisioning",
+                    exception
+                )
+
+                handleConnectionError(
+                    "Failed to start provisioning: " +
+                        (exception.message ?: "Unknown error")
+                )
+            }
+        }
+    }
+
+    override fun onProvisioningFailed(
+        meshNode: UnprovisionedMeshNode,
+        state: ProvisioningState.States,
+        data: ByteArray
+    ) {
+        Log.e(
+            TAG,
+            "Provisioning failed: $state"
+        )
+
+        eventHandler.sendError(
+            "Provisioning failed: ${state.name}"
+        )
+
+        cleanupProvisioningState(
+            closeConnection = true
+        )
+    }
+
+    override fun onProvisioningCompleted(
+        meshNode: ProvisionedMeshNode,
+        state: ProvisioningState.States,
+        data: ByteArray
+    ) {
+        provisioningCompleted = true
+
+        Log.d(
+            TAG,
+            "Provisioning completed. " +
+                "unicastAddress=${meshNode.unicastAddress}"
+        )
+
+        eventHandler.sendEvent(
+            status = ProvisioningEventStreamHandler.STATUS_COMPLETE,
+            data = mapOf(
+                "message" to "Provisioning complete!",
+                "unicastAddress" to meshNode.unicastAddress
+            )
+        )
+
+        /*
+         * Eventを送ってからGATT接続を終了する。
+         */
+        provisioningConnection.disconnect()
+    }
+
+    // -------------------------------------------------------------------------
+    // MeshStatusCallbacks
+    // -------------------------------------------------------------------------
+
+    override fun onTransactionFailed(
+        dst: Int,
+        hasIncompleteTimerExpired: Boolean
+    ) {
+        Log.e(
+            TAG,
+            "Mesh transaction failed: " +
+                "dst=$dst, " +
+                "timerExpired=$hasIncompleteTimerExpired"
+        )
+    }
+
+    override fun onUnknownPduReceived(
+        src: Int,
+        accessPayload: ByteArray
+    ) {
+        Log.w(
+            TAG,
+            "Unknown PDU received from $src"
+        )
+    }
+
+    override fun onBlockAcknowledgementProcessed(
+        dst: Int,
+        message: ControlMessage
+    ) = Unit
+
+    override fun onBlockAcknowledgementReceived(
+        src: Int,
+        message: ControlMessage
+    ) = Unit
+
+    override fun onHeartbeatMessageReceived(
+        src: Int,
+        message: ControlMessage
+    ) = Unit
+
+    override fun onMeshMessageProcessed(
+        dst: Int,
+        meshMessage: MeshMessage
+    ) = Unit
+
+    override fun onMeshMessageReceived(
+        src: Int,
+        meshMessage: MeshMessage
+    ) = Unit
+
+    override fun onMessageDecryptionFailed(
+        meshLayer: String,
+        errorMessage: String
+    ) {
+        Log.e(
+            TAG,
+            "Message decryption failed: " +
+                "layer=$meshLayer, error=$errorMessage"
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private fun handleConnectionError(message: String) {
+        Log.e(TAG, message)
+
+        eventHandler.sendError(message)
+
+        cleanupProvisioningState(
+            closeConnection = true
+        )
+    }
+
+    private fun cleanupProvisioningState(
+        closeConnection: Boolean
+    ) {
+        if (closeConnection) {
+            provisioningConnection.close()
+        }
+
+        targetDevice = null
+        targetMeshDeviceUuid = null
+        currentMtu = DEFAULT_MTU
+        provisioningCompleted = false
+    }
+
+    private fun respond(
+        result: MethodChannel.Result,
+        isSuccess: Boolean,
+        message: String
+    ) {
+        result.success(
+            mapOf(
+                "isSuccess" to isSuccess,
+                "message" to message
+            )
+        )
+    }
+}

--- a/android/app/src/main/kotlin/jp/ac/saitama_u/mech/human/soccerAppFlutter/flutterchannels/FlutterChannelManager.kt
+++ b/android/app/src/main/kotlin/jp/ac/saitama_u/mech/human/soccerAppFlutter/flutterchannels/FlutterChannelManager.kt
@@ -4,24 +4,46 @@ import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodChannel
 import jp.ac.saitama_u.mech.human.soccerAppFlutter.bluetooth.GeneralBleScanner
+import jp.ac.saitama_u.mech.human.soccerAppFlutter.bluetooth.ProvisioningService
 
 class FlutterChannelManager(
     private val messenger: BinaryMessenger,
-    private val bleScanner: GeneralBleScanner
+    private val bleScanner: GeneralBleScanner,
+    private val provisioningService: ProvisioningService,
+    private val provisioningEventStreamHandler:
+        ProvisioningEventStreamHandler
 ) {
+
     companion object {
-        private const val DOMAIN = "human.mech.saitama-u.ac.jp"
-        private const val SCANNER_METHOD_CHANNEL = "$DOMAIN/scannerMethodChannel"
-        private const val SCANNER_EVENT_CHANNEL = "$DOMAIN/scannerEventChannel"
+        private const val DOMAIN =
+            "human.mech.saitama-u.ac.jp"
+
+        private const val SCANNER_METHOD_CHANNEL =
+            "$DOMAIN/scannerMethodChannel"
+
+        private const val SCANNER_EVENT_CHANNEL =
+            "$DOMAIN/scannerEventChannel"
+
+        private const val PROVISIONING_METHOD_CHANNEL =
+            "$DOMAIN/provisioningMethodChannel"
+
+        private const val PROVISIONING_EVENT_CHANNEL =
+            "$DOMAIN/provisioningEventChannel"
     }
 
     fun setupChannels() {
-        setupMethodChannels()
-        setupEventChannels()
+        setupScannerMethodChannel()
+        setupProvisioningMethodChannel()
+        setupScannerEventChannel()
+        setupProvisioningEventChannel()
     }
 
-    private fun setupMethodChannels() {
-        MethodChannel(messenger, SCANNER_METHOD_CHANNEL).setMethodCallHandler { call, result ->
+    private fun setupScannerMethodChannel() {
+        MethodChannel(
+            messenger,
+            SCANNER_METHOD_CHANNEL
+        ).setMethodCallHandler { call, result ->
+
             when (call.method) {
                 "startScanning" -> {
                     bleScanner.startScan()
@@ -38,7 +60,52 @@ class FlutterChannelManager(
         }
     }
 
-    private fun setupEventChannels() {
-        EventChannel(messenger, SCANNER_EVENT_CHANNEL).setStreamHandler(bleScanner)
+    private fun setupProvisioningMethodChannel() {
+        MethodChannel(
+            messenger,
+            PROVISIONING_METHOD_CHANNEL
+        ).setMethodCallHandler { call, result ->
+
+            when (call.method) {
+                "provisioning" -> {
+                    val deviceId =
+                        call.argument<String>("uuid")
+
+                    if (deviceId == null) {
+                        result.success(
+                            mapOf(
+                                "isSuccess" to false,
+                                "message" to
+                                    "UUID key not found in arguments."
+                            )
+                        )
+                        return@setMethodCallHandler
+                    }
+
+                    provisioningService.startProvisioningProcess(
+                        deviceId = deviceId,
+                        result = result
+                    )
+                }
+
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    private fun setupScannerEventChannel() {
+        EventChannel(
+            messenger,
+            SCANNER_EVENT_CHANNEL
+        ).setStreamHandler(bleScanner)
+    }
+
+    private fun setupProvisioningEventChannel() {
+        EventChannel(
+            messenger,
+            PROVISIONING_EVENT_CHANNEL
+        ).setStreamHandler(
+            provisioningEventStreamHandler
+        )
     }
 }

--- a/android/app/src/main/kotlin/jp/ac/saitama_u/mech/human/soccerAppFlutter/flutterchannels/ProvisioningEventStreamHandler.kt
+++ b/android/app/src/main/kotlin/jp/ac/saitama_u/mech/human/soccerAppFlutter/flutterchannels/ProvisioningEventStreamHandler.kt
@@ -1,0 +1,75 @@
+package jp.ac.saitama_u.mech.human.soccerAppFlutter.flutterchannels
+
+import android.os.Handler
+import android.os.Looper
+import io.flutter.plugin.common.EventChannel
+
+/**
+ * Provisioningの進捗をAndroid NativeからFlutterへ通知するクラス。
+ *
+ * iOS版のProvisioningEventStreamHandler.swiftに対応する。
+ */
+class ProvisioningEventStreamHandler : EventChannel.StreamHandler {
+
+    companion object {
+        const val STATUS_CONNECTING = "connecting"
+        const val STATUS_DISCOVERING = "discovering"
+        const val STATUS_IDENTIFYING = "identifying"
+        const val STATUS_PROVISIONING = "provisioning"
+        const val STATUS_COMPLETE = "complete"
+        const val STATUS_ERROR = "error"
+    }
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    private var eventSink: EventChannel.EventSink? = null
+
+    /**
+     * FlutterがEventChannelの購読を開始したときに呼ばれる。
+     */
+    override fun onListen(
+        arguments: Any?,
+        events: EventChannel.EventSink?
+    ) {
+        eventSink = events
+    }
+
+    /**
+     * FlutterがEventChannelの購読を解除したときに呼ばれる。
+     */
+    override fun onCancel(arguments: Any?) {
+        eventSink = null
+    }
+
+    /**
+     * Provisioningの進捗をFlutterへ送る。
+     *
+     * @param status connecting、provisioning、completeなどの状態
+     * @param data Flutterへ送る追加データ
+     */
+    fun sendEvent(
+        status: String,
+        data: Map<String, Any?> = emptyMap()
+    ) {
+        val sink = eventSink ?: return
+
+        val eventData = HashMap<String, Any?>()
+        eventData.putAll(data)
+        eventData["status"] = status
+
+        // EventSinkへの送信はメインスレッドで実行する。
+        mainHandler.post {
+            sink.success(eventData)
+        }
+    }
+
+    /**
+     * エラー情報をFlutterへ送る。
+     */
+    fun sendError(message: String) {
+        sendEvent(
+            status = STATUS_ERROR,
+            data = mapOf("message" to message)
+        )
+    }
+}

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.14'
+platform :osx, '10.15'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,0 +1,57 @@
+PODS:
+  - Firebase/CoreOnly (11.13.0):
+    - FirebaseCore (~> 11.13.0)
+  - firebase_core (3.14.0):
+    - Firebase/CoreOnly (~> 11.13.0)
+    - FlutterMacOS
+  - FirebaseCore (11.13.0):
+    - FirebaseCoreInternal (~> 11.13.0)
+    - GoogleUtilities/Environment (~> 8.1)
+    - GoogleUtilities/Logger (~> 8.1)
+  - FirebaseCoreInternal (11.13.0):
+    - "GoogleUtilities/NSData+zlib (~> 8.1)"
+  - FlutterMacOS (1.0.0)
+  - GoogleUtilities/Environment (8.1.0):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Logger (8.1.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Privacy
+  - "GoogleUtilities/NSData+zlib (8.1.0)":
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Privacy (8.1.0)
+  - path_provider_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - firebase_core (from `Flutter/ephemeral/.symlinks/plugins/firebase_core/macos`)
+  - FlutterMacOS (from `Flutter/ephemeral`)
+  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
+
+SPEC REPOS:
+  trunk:
+    - Firebase
+    - FirebaseCore
+    - FirebaseCoreInternal
+    - GoogleUtilities
+
+EXTERNAL SOURCES:
+  firebase_core:
+    :path: Flutter/ephemeral/.symlinks/plugins/firebase_core/macos
+  FlutterMacOS:
+    :path: Flutter/ephemeral
+  path_provider_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
+
+SPEC CHECKSUMS:
+  Firebase: 3435bc66b4d494c2f22c79fd3aae4c1db6662327
+  firebase_core: 1095fcf33161d99bc34aa10f7c0d89414a208d15
+  FirebaseCore: c692c7f1c75305ab6aff2b367f25e11d73aa8bd0
+  FirebaseCoreInternal: 29d7b3af4aaf0b8f3ed20b568c13df399b06f68c
+  FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
+  GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+
+PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
+
+COCOAPODS: 1.16.2

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		A26FF9270DADEF82C2F8D8E0 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC56A882CBBC79A47518FA1E /* Pods_Runner.framework */; };
+		D04A0A03C9B0458C18A0138B /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67892AD1485DC69F84627419 /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -77,9 +79,17 @@
 		33E51913231747F40026EE4D /* DebugProfile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DebugProfile.entitlements; sourceTree = "<group>"; };
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
+		37CB2A2A7B8F18746FFB9C1A /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		42580B128F97935044C86B71 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		67892AD1485DC69F84627419 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		7ED93FB79706C7031F909CD4 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		8291F562EAB57197E4C4E616 /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Runner/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		AC56A882CBBC79A47518FA1E /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C1CC8EC0A619EBD39A9C8FC0 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		C3D1406DC7DD9A1575DD09AD /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		C8C8271D0889CD7E34A7E100 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -87,6 +97,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D04A0A03C9B0458C18A0138B /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -94,6 +105,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A26FF9270DADEF82C2F8D8E0 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -128,6 +140,7 @@
 				33CC10EE2044A3C60003C045 /* Products */,
 				D73912EC22F37F3D000D13A0 /* Frameworks */,
 				8291F562EAB57197E4C4E616 /* GoogleService-Info.plist */,
+				57F5DAA3119777683C0E7708 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -175,9 +188,25 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		57F5DAA3119777683C0E7708 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				42580B128F97935044C86B71 /* Pods-Runner.debug.xcconfig */,
+				C1CC8EC0A619EBD39A9C8FC0 /* Pods-Runner.release.xcconfig */,
+				C8C8271D0889CD7E34A7E100 /* Pods-Runner.profile.xcconfig */,
+				C3D1406DC7DD9A1575DD09AD /* Pods-RunnerTests.debug.xcconfig */,
+				7ED93FB79706C7031F909CD4 /* Pods-RunnerTests.release.xcconfig */,
+				37CB2A2A7B8F18746FFB9C1A /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		D73912EC22F37F3D000D13A0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				AC56A882CBBC79A47518FA1E /* Pods_Runner.framework */,
+				67892AD1485DC69F84627419 /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -189,6 +218,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C80DE294CF71000263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				B3F26246950011B94165BB49 /* [CP] Check Pods Manifest.lock */,
 				331C80D1294CF70F00263BE5 /* Sources */,
 				331C80D2294CF70F00263BE5 /* Frameworks */,
 				331C80D3294CF70F00263BE5 /* Resources */,
@@ -207,11 +237,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				A48278FC4766B41191DB6F90 /* [CP] Check Pods Manifest.lock */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				B4C7B8E72616178B502B6C0C /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -333,6 +365,67 @@
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
 		};
+		A48278FC4766B41191DB6F90 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B3F26246950011B94165BB49 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B4C7B8E72616178B502B6C0C /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -384,6 +477,7 @@
 /* Begin XCBuildConfiguration section */
 		331C80DB294CF71000263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = C3D1406DC7DD9A1575DD09AD /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -398,6 +492,7 @@
 		};
 		331C80DC294CF71000263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7ED93FB79706C7031F909CD4 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -412,6 +507,7 @@
 		};
 		331C80DD294CF71000263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 37CB2A2A7B8F18746FFB9C1A /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -465,7 +561,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -547,7 +643,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -597,7 +693,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/macos/Runner.xcworkspace/contents.xcworkspacedata
+++ b/macos/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>


### PR DESCRIPTION
# 1. Nordic Meshライブラリを追加した

まずAndroid側でBluetooth Meshを扱うために、`build.gradle.kts`へNordicのMeshライブラリを追加しました。

```
dependencies {
implementation("no.nordicsemi.android:mesh:3.4.0")
}
```

これによって、以下のようなクラスを使えるようになりました。

```
MeshManagerApi
MeshManagerCallbacks
MeshProvisioningStatusCallbacks
MeshStatusCallbacks
UnprovisionedMeshNode
ProvisionedMeshNode
ProvisioningState
```

この中で中心となるのが、

```
MeshManagerApi
```

です。

役割は、

```
Mesh Networkの読込・保存
Provisioning PDUの生成
Provisioning PDUの解析
Provisioning状態の管理
Unicast Addressの割当
```

です。

---

# 2. GeneralBleScannerでProvisioningに必要な情報を保存した

最初のスキャン実装ではFlutterへ、

```
name
uuid
rssi
```

だけを送っていました。

ただし、Provisioningを行うためにはそれだけでは足りません。

Android Native側では、

```
BluetoothDevice
Mesh Provisioning Service Data
```

が必要です。

そこで、新しく

```
DiscoveredMeshDevice.kt
```

を作りました。

中身は概ね次のようなデータ構造です。

```
dataclassDiscoveredMeshDevice(
valbluetoothDevice:BluetoothDevice,
valserviceData:ByteArray,
valname:String,
valrssi:Int
)
```

そして、`GeneralBleScanner.kt`のスキャン結果を、

```
valdiscoveredDevices:
MutableMap<String,DiscoveredMeshDevice>
```

に保存しました。

キーはAndroid側ではBluetoothアドレスです。

```
CE:79:02:17:00:A0
```

Flutter側では既存仕様に合わせて、この値を`uuid`という名前で扱っています。

---

# 3. 0x1827のService Dataを取得した

未ProvisioningのBluetooth Meshデバイスは、

```
Mesh Provisioning Service
UUID: 0x1827
```

を広告しています。

`GeneralBleScanner.kt`では、スキャン結果の`ScanRecord`から0x1827のService Dataを取得しました。

```
valserviceData=scanRecord.getServiceData(
ParcelUuid(MESH_PROVISIONING_SERVICE_UUID)
)
```

このService Dataには、Nordic Mesh SDKがProvisioning対象を識別するために使うMesh Device UUIDが含まれています。

そのため、

```
Flutter表示用
name / Bluetooth address / RSSI

Android Provisioning用
BluetoothDevice / ServiceData
```

を分けて保持しました。

---

# 4. MainActivityでMesh関連クラスを生成した

iOSでは`AppDelegate.swift`が各クラスを生成していました。

Androidでは`MainActivity.kt`がその役割を担当しています。

作成したものは、

```
MeshManagerApi
GeneralBleScanner
ProvisioningEventStreamHandler
ProvisioningService
FlutterChannelManager
```

です。

イメージはこうです。

```
MainActivity
├─ MeshManagerApi
├─ GeneralBleScanner
├─ ProvisioningEventStreamHandler
├─ ProvisioningService
└─ FlutterChannelManager
```

重要なのは、`MeshManagerApi`を1つだけ生成し、Provisioning処理全体で共有したことです。

---

# 5. FlutterChannelManagerにProvisioning用Channelを追加した

スキャン用とは別に、Provisioning用のMethodChannelとEventChannelを追加しました。

```
provisioningMethodChannel
provisioningEventChannel
```

Flutterから、

```
invokeMethod(
'provisioning',
  {'uuid':device.uuid},
)
```

が呼ばれると、Android側で、

```
provisioningService.startProvisioningProcess(
deviceId=deviceId,
result=result
)
```

を実行します。

つまり`FlutterChannelManager`は、

```
Flutterから届いたProvisioning命令を
ProvisioningServiceへ振り分ける受付窓口
```

です。

---

# 6. ProvisioningEventStreamHandlerを作った

Provisioningは一瞬で終わる処理ではありません。

状態が順番に変化します。

```
connecting
discovering
identifying
provisioning
complete
error
```

これをFlutterへ通知するために、

```
ProvisioningEventStreamHandler.kt
```

を作りました。

例えば、

```
eventHandler.sendEvent(
status="connecting",
data=mapOf(
"message"to"Connecting to device..."
    )
)
```

とすると、Flutter側では、

```
{
  "status": "connecting",
  "message": "Connecting to device..."
}
```

のように受け取れます。

その結果、アプリ画面で、

```
接続中
サービス検索中
識別中
プロビジョニング中
完了
```

を表示できるようになりました。

---

# 7. ProvisioningServiceを作った

`ProvisioningService.kt`は、Provisioning全体の司令塔です。

主な仕事は、

```
Flutterから対象デバイスIDを受け取る
スキャン済みデバイスを取得する
Mesh Device UUIDを取得する
スキャンを停止する
ProvisioningConnectionへ接続を依頼する
Nordic Mesh SDKのCallbackを受け取る
進捗をFlutterへ通知する
```

です。

Provisioning開始時には、

```
valdiscoveredDevice=
bleScanner.getDiscoveredDevice(deviceId)
```

で、スキャン時に保存したデバイスを取得します。

次に、

```
valmeshDeviceUuid=
meshManagerApi.getDeviceUuid(
discoveredDevice.serviceData
    )
```

でMesh Device UUIDを取り出しました。

その後、

```
provisioningConnection.connect(
discoveredDevice.bluetoothDevice
)
```

でGATT接続を開始しました。

---

# 8. ProvisioningConnectionを新しく作った

`ProvisioningConnection.kt`は、AndroidのBLE GATT通信だけを担当するクラスです。

役割は、

```
BLE接続
MTU変更
Service Discovery
Characteristic取得
Notification有効化
PDU書き込み
通知受信
切断
```

です。

`ProvisioningService`と分けた理由は、

```
ProvisioningService
= Provisioningの流れを管理

ProvisioningConnection
= Bluetooth GATT通信を管理
```

という責務分離をするためです。

---

# 9. connectGattで未Provisioningデバイスへ接続した

Androidでは、

```
device.connectGatt(
context,
false,
gattCallback,
BluetoothDevice.TRANSPORT_LE
)
```

で接続しました。

接続結果は、

```
onConnectionStateChange()
```

に返されます。

成功時は、

```
status = 0
newState = 2
```

となりました。

ログでは、

```
Provisioning device connected
```

まで確認できました。

---

# 10. MTUを要求した

接続後、より大きなデータを送れるように、

```
gatt.requestMtu(247)
```

を呼びました。

ただし、実機側が受け入れたMTUは、

```
ATT MTU = 33
```

でした。

つまりCharacteristicへ1回で書き込める最大データ量は、

```
33 - 3 = 30 bytes
```

です。

この30bytesという値が、後のPublic Key送信で非常に重要になりました。

---

# 11. Mesh Provisioning Serviceを探索した

MTU確定後に、

```
gatt.discoverServices()
```

を呼びました。

そして、

```
0x1827
Mesh Provisioning Service
```

を取得しました。

さらに、そのService内から、

```
0x2ADB
Provisioning Data In

0x2ADC
Provisioning Data Out
```

を取得しました。

それぞれの役割は、

```
2ADB
スマホ → Meshデバイス

2ADC
Meshデバイス → スマホ
```

です。

---

# 12. Notificationを有効化した

MeshデバイスからProvisioning PDUを受信するために、2ADCの通知を有効化しました。

```
gatt.setCharacteristicNotification(
characteristic,
true
)
```

さらにCCCDへ、

```
BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
```

を書き込みました。

成功すると、

```
listener.onReady(currentAttMtu)
```

を呼び、ProvisioningServiceへ、

```
GATT接続準備完了
```

を通知しました。

---

# 13. identifyNodeを実行した

GATT準備完了後、

```
meshManagerApi.identifyNode(
meshDeviceUuid,
5
)
```

を呼びました。

これによってNordic Mesh SDKが、

```
Provisioning Invite
```

を生成しました。

状態Callbackでは、

```
PROVISIONING_INVITE
```

になりました。

そしてSDKが生成したPDUは、

```
sendProvisioningPdu()
```

へ返ってきました。

---

# 14. SDKが生成したPDUをBLEへ送った

`ProvisioningService`の、

```
overridefunsendProvisioningPdu(
meshNode:UnprovisionedMeshNode,
pdu:ByteArray
)
```

で、

```
provisioningConnection.writeProvisioningPdu(pdu)
```

を呼びました。

これによって、

```
Nordic Mesh SDK
↓
ProvisioningService
↓
ProvisioningConnection
↓
2ADB Characteristic
↓
Meshデバイス
```

という送信経路が完成しました。

---

# 15. 最初はPublic Key送信で失敗した

最初の実装では、67〜68bytesのPublic Key PDUを1回で送っていました。

しかし実際の書き込み可能サイズは、

```
30bytes
```

でした。

そのため、

```
3bytes Invite → 成功
7bytes Start → 成功
67bytes Public Key → 相手が切断
```

となり、

```
GATT status=19
```

が発生しました。

これは相手デバイス側から接続を終了された状態でした。

---

# 16. PDUをMTUサイズごとに分割した

この問題を解決するために、書き込みキューを追加しました。

```
privatevalwriteQueue=
ArrayDeque<ByteArray>()
```

68bytesのPublic Key PDUを、

```
30bytes
30bytes
8bytes
```

に分割しました。

ログでも、

```
Provisioning data queued:
total=68
packets=3
packetSize=30
```

と確認できました。

---

# 17. 1パケットずつ順番に送信した

BLE GATTでは、複数の書き込みを同時に投げると不安定になります。

そこで、

```
1パケット送信
↓
onCharacteristicWrite
↓
次のパケット送信
```

という順番にしました。

実装としては、

```
writeNextPacket()
```

を使い、

```
onCharacteristicWrite()
```

が成功した後に、次のデータを送りました。

これによってPublic Key PDUを最後まで正常に送信できました。

---

# 18. デバイスからの通知をNordic SDKへ渡した

2ADCから通知が届くと、

```
onCharacteristicChanged()
```

が呼ばれます。

そこから、

```
listener.onNotificationReceived(data)
```

を通してProvisioningServiceへ渡しました。

ProvisioningService側では、

```
meshManagerApi.handleNotifications(
currentMtu,
data
)
```

を呼びました。

これによってNordic Mesh SDKが、

```
Capabilities
Public Key
Confirmation
Random
Complete
```

などを解析できるようになりました。

---

# 19. 書き込み完了もSDKへ返した

PDUの書き込み成功後は、

```
listener.onWriteCompleted(data)
```

を呼びました。

ProvisioningServiceでは、

```
meshManagerApi.handleWriteCallbacks(
currentMtu,
data
)
```

を呼びました。

これによりNordic Mesh SDKは、

```
このPDUは正常に送信された
```

と認識し、次のProvisioning状態へ進みました。

---

# 20. Capabilities受信後にProvisioning本体を開始した

状態が、

```
PROVISIONING_CAPABILITIES
```

になったタイミングで、

```
meshManagerApi.startProvisioning(meshNode)
```

を呼びました。

これにより、

```
Start
Public Key交換
Confirmation交換
Random交換
Provisioning Data送信
```

へ進みました。

---

# 21. Provisioningの状態をCallbackで管理した

`ProvisioningService`は、

```
MeshProvisioningStatusCallbacks
```

を実装しました。

これにより、

```
PROVISIONING_INVITE
PROVISIONING_CAPABILITIES
PROVISIONING_START
PROVISIONING_PUBLIC_KEY_SENT
PROVISIONING_PUBLIC_KEY_RECEIVED
PROVISIONING_CONFIRMATION_SENT
PROVISIONING_CONFIRMATION_RECEIVED
PROVISIONING_RANDOM_RECEIVED
PROVISIONING_DATA_SENT
```

などの状態を受け取れました。

各状態をFlutterへEventChannelで送ったことで、UIの進捗表示が動きました。

---

# 22. Provisioning完了を受信した

最後にMeshデバイスから、

```
0x0308
```

が返ってきました。

これはProvisioning Completeです。

ログでは、

```
Mesh Network updated
Provisioning completed. unicastAddress=1
```

となりました。

つまり対象デバイスは、

```
未Provisioningデバイス
↓
Mesh Network参加済みNode
```

になりました。

さらに、

```
Unicast Address = 0x0001
```

が割り当てられました。

---

# 23. 完了後に正常切断した

Provisioning完了後、

```
provisioningConnection.disconnect()
```

を呼びました。

最終ログは、

```
status=0
connected=false
```

だったため、これは異常切断ではなく正常な切断です。

---

# 実装したファイルごとの役割

```
GeneralBleScanner.kt
未Provisioningデバイスを探す

DiscoveredMeshDevice.kt
Provisioningに必要なNative情報を保持する

MainActivity.kt
各クラスを生成して接続する

FlutterChannelManager.kt
Flutterからの命令を各Serviceへ振り分ける

ProvisioningEventStreamHandler.kt
Provisioning進捗をFlutterへ送る

ProvisioningService.kt
Provisioning全体の流れを管理する

ProvisioningConnection.kt
BLE GATT接続・PDU送受信を担当する

MeshManagerApi
Provisioning PDUの生成・解析・Mesh Network管理
```

# 最終的に完成した通信経路

```
Flutter UI
↓
provisioning.dart
↓
MethodChannel
↓
FlutterChannelManager.kt
↓
ProvisioningService.kt
↓
ProvisioningConnection.kt
↓
BluetoothGatt
↓
Meshデバイス
```

返りは、

```
Meshデバイス
↓
Notification
↓
ProvisioningConnection.kt
↓
ProvisioningService.kt
↓
MeshManagerApi
↓
ProvisioningEventStreamHandler.kt
↓
EventChannel
↓
Flutter UI
```

です。